### PR TITLE
Used more proper session timing + modals

### DIFF
--- a/winterfell/controllers/authController.js
+++ b/winterfell/controllers/authController.js
@@ -72,7 +72,7 @@ module.exports = function (app) {
   app.get('/auth/logout', function(req, res) {
     console.log('[authLogOut] log out for ' + JSON.stringify(req.session));
     req.session.destroy(function (err) {
-        if(err){
+        if(err) {
             console.log(err);
             res.end('done');
         } else {

--- a/winterfell/controllers/sessionController.js
+++ b/winterfell/controllers/sessionController.js
@@ -3,26 +3,14 @@ var Constants = require('../utils/constants');
 
 module.exports = function (app) {
 
-  // Endpoint for checking if session still exists on server
-  app.get('/session/check', function(req, res) {
-    console.log('[sessionCheck] request received');
+  // Endpoint for updating the session TTL
+  app.get('/session/touch', function(req, res) {
+    console.log('[sessionTouch] request received');
     if (req.session.key) {
       res.sendStatus(200);
     } else {
+      console.log('[sessionTouch] session expired!');
       res.sendStatus(404);
     }
   });
-
-  // Endpoint for updating session and increasing its TTL
-  app.post('/session/extend', function (req, res) {
-    console.log('[sessionCheck] request received for ' + JSON.stringify(req.body));
-    if (req.session.key) {
-      var client = RedisService.getClient();
-      client.expire(req.session.key, Constants.SESSION_EXPIRE_TIME);
-      res.sendStatus(200);
-    } else {
-      res.sendStatus(404);
-    }
-  });
-
 };

--- a/winterfell/webapp/src/js/net.js
+++ b/winterfell/webapp/src/js/net.js
@@ -42,11 +42,8 @@ app.factory('net', ['$http', function($http) {
     signup: function(userData) {
       return httpPost("/auth/signup", userData);
     },
-    checkSession: function() {
-      return httpGet("/session/check");
-    },
-    extendSession: function() {
-      return httpPost("/session/extend");
+    touchSession: function() {
+      return httpGet("/session/touch");
     },
     getUserInfo: function() {
       var userId = getSessionUserId();

--- a/winterfell/webapp/src/js/profileService.js
+++ b/winterfell/webapp/src/js/profileService.js
@@ -5,7 +5,7 @@ app.factory('profileService', function() {
     userInfo: {},
     clearUserInfo: function() {
       sessionStorageHelper.removePair(vfiConstants.keyUserId);
-      userInfo = {};
+      this.userInfo = {};
     }
   };
 });

--- a/winterfell/webapp/src/styles/modals/modal.styl
+++ b/winterfell/webapp/src/styles/modals/modal.styl
@@ -14,3 +14,11 @@
     width: 100%
     margin: mediumSpacing 0
     border-bottom: 1px solid colorLightGray
+
+  & p
+    margin: largeSpacing 0
+    line-height: bodyFont_lineHeight
+    font-family: SourceSansPro
+    font-weight: bodyFont_weight
+    font-size: bodyFont_size
+    letter-spacing: bodyFont_letterSpacing

--- a/winterfell/webapp/src/styles/modals/sessionExpired.styl
+++ b/winterfell/webapp/src/styles/modals/sessionExpired.styl
@@ -1,0 +1,7 @@
+
+#session-expired
+  & p
+    text-align: center
+
+  & .vfi-button-row
+    text-align: center

--- a/winterfell/webapp/src/templates/modals/sessionExpired.jade
+++ b/winterfell/webapp/src/templates/modals/sessionExpired.jade
@@ -1,0 +1,8 @@
+div.vfi-modal#session-expired
+  div.vfi-title Session Expired
+  div.vfi-title-separator
+  p
+    | For security reasons, your session has expired due to inactivity.
+    | Please log back in to continue your work.
+  div.vfi-button-row
+    button(ng-click="closeThisDialog()") OK


### PR DESCRIPTION
"Session Expired" modal now appears when the client believes you are inactive.

It works like so:
When you sign in, we check if you've been inactive every 20 minutes.
If you are not inactive, we send a request to the server to extend your session key's TTL (time to live).
If you are inactive, we log out, redirect to homepage and a dialog modal pops up saying "your session has expired for security reasons... blahblah"

We consider being active if network requests have been called or if routes have changed.
We can broaden this part more later.
