### PR TITLE
Sets Up Biscuit to Manage Secrets

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/config/biscuit/secrets.yaml
+++ b/config/biscuit/secrets.yaml
@@ -1,0 +1,10 @@
+_keys:
+- key_id: arn:aws:kms:us-east-1:477593580061:alias/biscuit-default
+  key_manager: kms
+  algorithm: secretbox
+- key_id: arn:aws:kms:us-west-1:477593580061:alias/biscuit-default
+  key_manager: kms
+  algorithm: secretbox
+- key_id: arn:aws:kms:us-west-2:477593580061:alias/biscuit-default
+  key_manager: kms
+  algorithm: secretbox

--- a/config/packer/scripts/dep.sh
+++ b/config/packer/scripts/dep.sh
@@ -38,3 +38,10 @@ echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selecti
 apt-get -y install oracle-java8-installer
 # Set default java
 apt-get -y install oracle-java8-set-default
+
+# Biscuit (secrets management)
+wget https://github.com/dcoker/biscuit/releases/download/v0.1.2/biscuit-linux_amd64.tgz
+tar -xzvf biscuit-linux_amd64.tgz
+chmod +x biscuit
+mv biscuit /usr/local/bin/biscuit
+rm biscuit-linux_amd64.tgz

--- a/config/packer/vetafi-ubuntu-14.04.4-server-amd64.json
+++ b/config/packer/vetafi-ubuntu-14.04.4-server-amd64.json
@@ -97,7 +97,7 @@
             "artifact_type": "vagrant.box",
             "metadata": {
                 "provider": "vmware_desktop",
-                "version": "0.0.3"
+                "version": "0.0.4"
             }
         },
         {
@@ -107,7 +107,7 @@
             "artifact_type": "vagrant.box",
             "metadata": {
                 "provider": "virtualbox",
-                "version": "0.0.3"
+                "version": "0.0.4"
             }
         }]
     ]


### PR DESCRIPTION
Sets up biscuit which is a secret management tool. Biscuit will allow us to store sensitive things like certs, and API keys in `config/biscuit/secrets.yaml` and check them into github. The secrets are encrypted using AWS KMS, so only people with credentials on our aws account will be able to decrypt the secrets at runtime.

The decryption of secrets can be done via shell call to the `biscuit` binary at webserver startup, and the secrets can be stored in memory on the webserver.