### PR TITLE
give default sizings for header elements

### DIFF
--- a/winterfell/webapp/src/index.jade
+++ b/winterfell/webapp/src/index.jade
@@ -13,15 +13,15 @@ html(lang="en")
 			div#header-content(ng-controller="headerCtrl")
 				a.vfi-header-logo-wrapper(href="#/")
 					img.vfi-header-logo-img(src='../icons/logo.png')
-					div.vfi-header-logo Vetafi
+					h1.vfi-header-logo Vetafi
 				div.vfi-header-links
 
 					// If not signed in
 					a(href='/signup' ng-if='!isSignedIn')
-						| Sign Up
+						h3 Sign Up
 						.vfi-underline-border
 					a(href='/login' ng-if='!isSignedIn')
-						| Log In
+						h3 Log In
 						div.vfi-underline-border
 
 					// If signed in

--- a/winterfell/webapp/src/styles/claimConfirm.styl
+++ b/winterfell/webapp/src/styles/claimConfirm.styl
@@ -7,13 +7,6 @@
   box-sizing: border-box
   background-color: colorWhite
 
-& .vfi-header
-  line-height: heading1_lineHeight
-  font-family: Merriweather
-  font-weight: heading1_weight
-  font-size: heading1_size
-  letter-spacing: heading1_letterSpacing
-
 & .vfi-divider
   margin: largeSpacing 0
   border-bottom: 1px solid colorLightGray

--- a/winterfell/webapp/src/styles/claimStart.styl
+++ b/winterfell/webapp/src/styles/claimStart.styl
@@ -7,13 +7,6 @@
   box-sizing: border-box
   background-color: colorWhite
 
-  & .vfi-header
-    line-height: heading1_lineHeight
-    font-family: Merriweather
-    font-weight: heading1_weight
-    font-size: heading1_size
-    letter-spacing: heading1_letterSpacing
-
   & .vfi-divider
     margin: largeSpacing 0
     border-bottom: 1px solid colorLightGray

--- a/winterfell/webapp/src/styles/claimSubmitted.styl
+++ b/winterfell/webapp/src/styles/claimSubmitted.styl
@@ -7,13 +7,6 @@
   box-sizing: border-box
   background-color: colorWhite
 
-& .vfi-header
-  line-height: heading1_lineHeight
-  font-family: Merriweather
-  font-weight: heading1_weight
-  font-size: heading1_size
-  letter-spacing: heading1_letterSpacing
-
 & .vfi-divider
   margin: largeSpacing 0
   border-bottom: 1px solid colorLightGray

--- a/winterfell/webapp/src/styles/claimView.styl
+++ b/winterfell/webapp/src/styles/claimView.styl
@@ -53,17 +53,10 @@
         height: 24px
 
   & .vfi-title
-    font-family: Merriweather
-    line-height: heading1_lineHeight
     margin-bottom: miniSpacing
-    font-size: heading1_size
 
   & .vfi-subtitle
-    font-family: Merriweather
-    line-height: heading1_smaller_lineHeight
-    font-size: heading1_smaller_size
     margin-bottom: smallSpacing
-
 
   & .file-content
     height: megaSpacing
@@ -79,7 +72,7 @@
 
     & .file-title
       font-family: SourceSansPro
-      font-size: bodyFont_big_size
+      font-size: lead_size
 
     & .file-description
       font-family: SourceSansPro

--- a/winterfell/webapp/src/styles/faq.styl
+++ b/winterfell/webapp/src/styles/faq.styl
@@ -41,7 +41,7 @@ iconWarningSize = 56px
     line-height: largeSpacing
     box-sizing: border-box
     vertical-align: top
-    font-size: heading1_small_size
+    font-size: h3_size
     outline: none
     border: none
 
@@ -62,22 +62,10 @@ iconWarningSize = 56px
   padding: largeSpacing megaSpacing
   background-color: white
 
-  & .section-title
-    font-family: Merriweather
-    line-height: heading1_small_lineHeight
-    font-size: heading1_small_size
-    font-weight: heading1_small_weight
-
   & .section-divider
     margin-top: smallSpacing
     margin-bottom: smallSpacing
     border-bottom: 1px solid colorLightGray
-
-  & .section-content
-    font-family: SourceSansPro
-    line-height: bodyFont_lineHeight
-    font-size: bodyFont_size
-    font-weight: bodyFont_weight
 
 .section-card.vfi-error
   & .warning-icon

--- a/winterfell/webapp/src/styles/header.styl
+++ b/winterfell/webapp/src/styles/header.styl
@@ -25,11 +25,8 @@
 
   & .vfi-header-logo
     display: inline-block
+    margin-top: 4px
     color: colorWhite
-    font-family: Merriweather
-    font-size: heading1_big_size
-    font-weight: heading1_weight
-    letter-spacing: heading1_big_letterSpacing
 
     &:hover
       text-decoration: none
@@ -38,15 +35,15 @@
       display: none
 
 .vfi-header-links
+  height: headerHeightPx
   line-height: headerHeightPx
 
   & a
     position: relative
     float: right
+    margin-top: 15px
     margin-left: largeSpacing
     color: colorWhite
-    font-family: Merriweather
-    font-size: heading1_small_size
 
     &:hover
       text-decoration: none
@@ -57,11 +54,11 @@
         visibility: visible
 
     @media screen and (max-width: minWindowWidthPx)
-      font-size: heading1_mini_size
+      font-size: h5_size
 
   & .vfi-underline-border
     position: absolute
-    bottom: 10px
+    bottom: -8px
     width: 100%
     height: 2px
     background-color: white

--- a/winterfell/webapp/src/styles/home.styl
+++ b/winterfell/webapp/src/styles/home.styl
@@ -37,15 +37,10 @@
         margin: 0 auto
         line-height: 70px
         color: colorWhite
-        font-family: Merriweather
-        font-weight: 700
-        font-size: (heading1_size - 4)
-        letter-spacing: heading1_letterSpacing
         text-align: left
 
         @media screen and (max-width: maxWindowWidthPx)
           text-align: left
-          font-size: (heading1_small_size - 5)
         @media screen and (max-width: minWindowWidthPx)
           text-align: center
 
@@ -112,15 +107,10 @@
       padding: largeSpacing megaSpacing
 
     & .vfi-option-title
-      font-family: Merriweather
-      font-weight: heading1_weight
-      font-size: heading1_small_size
-      line-height: heading1_small_lineHeight
-      letter-spacing: heading1_small_letterSpacing
 
       @media screen and (max-width: minWindowWidthPx)
-        font-size: heading1_smaller_size
-        line-height: heading1_smaller_lineHeight
+        font-size: h4_size
+        line-height: h4_lineHeight
 
     & .vfi-option-text-wrapper
       display: inline-block

--- a/winterfell/webapp/src/styles/main.styl
+++ b/winterfell/webapp/src/styles/main.styl
@@ -72,7 +72,7 @@ body
 		line-height: h5_lineHeight
 		letter-spacing: h5_letterSpacing
 
-	& .lead-p
+	& .vfi-lead-p
 		margin: 0
 		font-family: Merriweather
 		font-weight: lead_weight

--- a/winterfell/webapp/src/styles/main.styl
+++ b/winterfell/webapp/src/styles/main.styl
@@ -8,7 +8,6 @@ body
 	font-weight: bodyFont_weight
 	font-size: bodyFont_size
 	line-height: bodyFont_lineHeight
-	letter-spacing: bodyFont_letterSpacing
 
 	& a
 		color: colorRed
@@ -32,3 +31,50 @@ body
 			-moz-filter: brightness(1.2)
 			-ms-filter: brightness(1.2)
 			cursor: pointer
+
+	& h1
+		margin: 0
+		font-family: Merriweather
+		font-weight: heading_weight
+		font-size: h1_size
+		line-height: h1_lineHeight
+		letter-spacing: h1_letterSpacing
+
+	& h2
+		margin: 0
+		font-family: Merriweather
+		font-weight: heading_weight
+		font-size: h2_size
+		line-height: h2_lineHeight
+		letter-spacing: h2_letterSpacing
+
+	& h3
+		margin: 0
+		font-family: Merriweather
+		font-weight: heading_weight
+		font-size: h3_size
+		line-height: h3_lineHeight
+		letter-spacing: h3_letterSpacing
+
+	& h4
+		margin: 0
+		font-family: Merriweather
+		font-weight: heading_weight
+		font-size: h4_size
+		line-height: h4_lineHeight
+		letter-spacing: h4_letterSpacing
+
+	& h5
+		margin: 0
+		font-family: Merriweather
+		font-weight: heading_weight
+		font-size: h5_size
+		line-height: h5_lineHeight
+		letter-spacing: h5_letterSpacing
+
+	& .lead-p
+		margin: 0
+		font-family: Merriweather
+		font-weight: lead_weight
+		font-size: lead_size
+		line-height: lead_lineHeight

--- a/winterfell/webapp/src/styles/modals/changePassword.styl
+++ b/winterfell/webapp/src/styles/modals/changePassword.styl
@@ -8,6 +8,6 @@
     padding: miniSpacing
     padding-left: smallSpacing
     font-family: SourceSansPro
-    font-size: bodyFont_big_size
+    font-size: lead_size
     font-weight: bodyFont_weight
     border: none

--- a/winterfell/webapp/src/styles/modals/modal.styl
+++ b/winterfell/webapp/src/styles/modals/modal.styl
@@ -3,13 +3,6 @@
 .vfi-modal
   padding: smallSpacing mediumSpacing
 
-  & .vfi-title
-    line-height: heading1_small_lineHeight
-    font-family: Merriweather
-    font-weight: heading1_weight
-    font-size: heading1_small_size
-    letter-spacing: heading1_small_letterSpacing
-
   & .vfi-title-separator
     width: 100%
     margin: mediumSpacing 0
@@ -17,8 +10,3 @@
 
   & p
     margin: largeSpacing 0
-    line-height: bodyFont_lineHeight
-    font-family: SourceSansPro
-    font-weight: bodyFont_weight
-    font-size: bodyFont_size
-    letter-spacing: bodyFont_letterSpacing

--- a/winterfell/webapp/src/styles/profile.styl
+++ b/winterfell/webapp/src/styles/profile.styl
@@ -74,13 +74,8 @@ borderType = 2px solid colorBorder
 .vfi-profile-basic-info
   display: inline-block
   color: colorWhite
-  font-weight: 400
-  font-size: heading1_smaller_size
-  line-height: heading1_smaller_lineHeight
 
   & .vfi-line:first-child
-    font-size: heading1_small_size
-    line-height: heading1_small_lineHeight
     margin-bottom: mediumSpacing
 
 .vfi-edit-info-btn
@@ -133,10 +128,6 @@ borderType = 2px solid colorBorder
 
     & .vfi-section-header
       margin-bottom: mediumSpacing
-      font-family: Merriweather
-      font-size: heading1_small_size
-      line-height: heading1_small_lineHeight
-      letter-spacing: heading1_letterSpacing
 
 //
 // Profile Military section

--- a/winterfell/webapp/src/styles/signin.styl
+++ b/winterfell/webapp/src/styles/signin.styl
@@ -38,20 +38,12 @@
     position: absolute
     top: largeSpacing
     left: 0
-    font-family: Merriweather
-    font-weight: 700
-    font-size: heading1_big_size
-    letter-spacing: heading1_big_letterSpacing
     color: colorBlack
 
   .vfi-subheading
     position: absolute
     bottom: largeSpacing
     left: 0
-    font-family: Merriweather
-    font-weight: 400
-    font-size: heading1_size
-    letter-spacing: heading1_letterSpacing
     color: colorBlack
 
   #signup-wrapper

--- a/winterfell/webapp/src/styles/standards.styl
+++ b/winterfell/webapp/src/styles/standards.styl
@@ -9,41 +9,38 @@
 	font-family SourceSansPro
 	src url('../fonts/SourceSansPro/SourceSansPro-Regular.ttf');
 
-heading1_weight = 700
-heading1_size = 30px									// 30px
-heading1_lineHeight = 1.3em						// 39px
-heading1_letterSpacing = 1.5px				// 1.5px
+// Headers
+heading_weight = 700
+h1_size = 40px							// 40px
+h1_lineHeight = 1.3em				// 52px
+h1_letterSpacing = 2px			// 2px
 
-heading1_big_weight = 700
-heading1_big_size = 40px							// 40px
-heading1_big_lineHeight = 1.3em				// 52px
-heading1_big_letterSpacing = 2px			// 2px
+h2_size = 30px							// 30px
+h2_lineHeight = 1.3em				// 39px
+h2_letterSpacing = 1.5px		// 1.5px
 
-heading1_small_weight = 700
-heading1_small_size = 20px						// 20px
-heading1_small_lineHeight = 1.3em			// 26px
-heading1_small_letterSpacing = 1px		// 1px
+h3_size = 20px							// 20px
+h3_lineHeight = 1.3em				// 26px
+h3_letterSpacing = 1px			// 1px
 
-heading1_smaller_weight = 700
-heading1_smaller_size = 17px					// 17px
-heading1_smaller_lineHeight = 1.3em		// 22px
-heading1_smaller_letterSpacing = 1px	// 1px
+h4_size = 17px							// 17px
+h4_lineHeight = 1.3em				// 22px
+h4_letterSpacing = 1px			// 1px
 
-heading1_mini_weight = 700
-heading1_mini_size = 15px							// 17px
-heading1_mini_lineHeight = 1.3em			// 22px
-heading1_mini_letterSpacing = 1px			// 1px
+h5_size = 15px							// 17px
+h5_lineHeight = 1.3em				// 22px
+h5_letterSpacing = 1px			// 1px
 
+// Lead Paragraph
+lead_family = Merriweather
+lead_weight = 400
+lead_size = 20px								// 20px
+lead_lineHeight = 1.7em					// 34px
+
+// Body Font
 bodyFont_weight = 400
-bodyFont_size = 17px									// 17px
-bodyFont_lineHeight = 1.5em						// 26px
-bodyFont_letterSpacing = 1px					// 1px
-
-bodyFont_big_weight = 400
-bodyFont_big_size = 20px							// 20px
-bodyFont_big_lineHeight = 1.7em				// 34px
-bodyFont_big_letterSpacing = 1px			// 1px
-
+bodyFont_size = 17px						// 17px
+bodyFont_lineHeight = 1.5em			// 26px
 
 //
 // US Gov Color Palette Standards ---> https://standards.usa.gov/visual-style/#palette

--- a/winterfell/webapp/src/styles/tos.styl
+++ b/winterfell/webapp/src/styles/tos.styl
@@ -13,14 +13,11 @@ leftSpacing = megaSpacing
   background-color: colorWhite
 
   .vfi-title
+    padding-top: miniSpacing
+    padding-bottom: miniSpacing
     padding-left: (leftSpacing / 2)
     background-color: colorPrimaryBlue
     color: colorWhite
-    font-family: Merriweather
-    font-weight: heading1_weight
-    font-size: heading1_size
-    line-height: (2 * heading1_lineHeight)
-    letter-spacing: heading1_letterSpacing
 
   .vfi-tos-scroller
     height: 250px
@@ -28,20 +25,12 @@ leftSpacing = megaSpacing
     overflow-y: auto
     border-bottom: 1px solid colorLightGray
 
-    & p
-      font-family: SourceSansPro
-      font-weight: bodyFont_weight
-      font-size: bodyFont_size
-      line-height: bodyFont_lineHeight
-      letter-spacing: bodyFont_letterSpacing
-
   .vfi-checkbox
     margin: largeSpacing 0 largeSpacing leftSpacing
     font-family: SourceSansPro
     font-weight: bodyFont_weight
     font-size: bodyFont_size
     line-height: bodyFont_lineHeight
-    letter-spacing: bodyFont_letterSpacing
 
     & input
       margin-right: mediumSpacing

--- a/winterfell/webapp/src/templates/claimConfirm.jade
+++ b/winterfell/webapp/src/templates/claimConfirm.jade
@@ -1,5 +1,5 @@
 #claim-confirm-view(ng-controller="claimConfirmCtrl")
-  div.vfi-header Confirm Claim
+  h2.vfi-header Confirm Claim
   div.vfi-divider
   p Words
   p Words

--- a/winterfell/webapp/src/templates/claimStart.jade
+++ b/winterfell/webapp/src/templates/claimStart.jade
@@ -1,5 +1,5 @@
 #claim-start-view(ng-controller="claimStartCtrl")
-  div.vfi-header Start Claim
+  h2.vfi-header Start Claim
   div.vfi-divider
   p Words
   p Words

--- a/winterfell/webapp/src/templates/claimSubmitted.jade
+++ b/winterfell/webapp/src/templates/claimSubmitted.jade
@@ -1,5 +1,5 @@
 #claim-submitted-view(ng-controller="claimSubmittedCtrl")
-  div.vfi-header Claim Submitted
+  h2.vfi-header Claim Submitted
   div.vfi-divider
   p Words
   p Words

--- a/winterfell/webapp/src/templates/claimView.jade
+++ b/winterfell/webapp/src/templates/claimView.jade
@@ -1,7 +1,7 @@
 #claim-view(ng-controller="claimViewCtrl")
   div.claim-header
-    div.vfi-title {{claim.title}}
-    div.vfi-subtitle {{claim.subtitle}}
+    h2.vfi-title {{claim.title}}
+    h4.vfi-subtitle {{claim.subtitle}}
     div.vfi-actions
       button.vfi-edit-btn
         div.vfi-icon

--- a/winterfell/webapp/src/templates/faq.jade
+++ b/winterfell/webapp/src/templates/faq.jade
@@ -6,7 +6,7 @@
     button.cancel-icon(ng-click="cancelSearch()" ng-show="searchText.length > 0")
 
   div.section-card(ng-repeat="section in sections | filter:searchText")
-    div.section-title {{section.title}}
+    h3.section-title {{section.title}}
     div.section-divider
     div.section-content {{section.content}}
 

--- a/winterfell/webapp/src/templates/home.jade
+++ b/winterfell/webapp/src/templates/home.jade
@@ -2,11 +2,11 @@
   div.vfi-banner-wrapper
     div.vfi-banner-img
     div.vfi-banner-overlay
-      div.vfi-banner-text-wrapper(ng-show="hasIncompleteClaim")
+      h3.vfi-banner-text-wrapper(ng-show="hasIncompleteClaim")
         | Continue your previous claim
         a(href="#/tos")
           button.vfi-banner-action Continue claim
-      div.vfi-banner-text-wrapper(ng-show="!hasIncompleteClaim")
+      h3.vfi-banner-text-wrapper(ng-show="!hasIncompleteClaim")
         | Get the benefits that you deserve
         a(href="#/tos")
           button.vfi-banner-action Start a claim
@@ -14,13 +14,13 @@
 
   div.vfi-home-option-wrapper
     a.vfi-home-option-link(href='#/signup')
-      div.vfi-option-title File a Health Claim
+      h3.vfi-option-title File a Health Claim
       div.vfi-option-text-wrapper
         p We can help you file a Fully Developed Claim. Completely submit your information once and avoid having to tediously go back and forth with the VA.
       img.vfi-icon-popup(src='../icons/home-folder.svg')
   div.vfi-home-option-wrapper
     a.vfi-home-option-link(href='#/faq')
-      div.vfi-option-title Learn about your Benefits
+      h3.vfi-option-title Learn about your Benefits
       div.vfi-option-text-wrapper
         p Got questions about what benefits and entitlements you are eligible for? Click here to learn about what you can do.
       img.vfi-icon-popup(src='../icons/home-health.svg')

--- a/winterfell/webapp/src/templates/modals/changePassword.jade
+++ b/winterfell/webapp/src/templates/modals/changePassword.jade
@@ -1,5 +1,5 @@
 div.vfi-modal#change-password
-  div.vfi-title Change Passwords
+  h3.vfi-title Change Passwords
   div.vfi-title-separator
   input(placeholder='Old password')
   input(placeholder='New password')

--- a/winterfell/webapp/src/templates/modals/sessionExpired.jade
+++ b/winterfell/webapp/src/templates/modals/sessionExpired.jade
@@ -1,5 +1,5 @@
 div.vfi-modal#session-expired
-  div.vfi-title Session Expired
+  h3.vfi-title Session Expired
   div.vfi-title-separator
   p
     | For security reasons, your session has expired due to inactivity.

--- a/winterfell/webapp/src/templates/noangular/signup.jade
+++ b/winterfell/webapp/src/templates/noangular/signup.jade
@@ -12,8 +12,8 @@ html(lang="en")
       #bg-overlay
 
       #view-wrapper
-        .vfi-heading Vetafi
-        .vfi-subheading  Lorem ipsum dolor sit amet consectetur
+        h1.vfi-heading Vetafi
+        h2.vfi-subheading  Lorem ipsum dolor sit amet consectetur
 
         #signup-wrapper
           h3 Sign up for an account

--- a/winterfell/webapp/src/templates/profile.jade
+++ b/winterfell/webapp/src/templates/profile.jade
@@ -9,11 +9,11 @@ div#profile-view(ng-controller="profileCtrl")
           | Change Profile Picture
         img.vfi-profile-pic(ng-src="{{userInfo.profileSrc || '../icons/default-profile.svg'}}" ng-class="{'vfi-default' : !userInfo.profileSrc}")
       div.vfi-profile-basic-info
-        div.vfi-line FirstName Middlename Lastname Suffix
-        div.vfi-line Email
-        div.vfi-line Address
-        div.vfi-line Gender
-        div.vfi-line Date of Birth
+        h4.vfi-line FirstName Middlename Lastname Suffix
+        h4.vfi-line Email
+        h4.vfi-line Address
+        h4.vfi-line Gender
+        h4.vfi-line Date of Birth
         button.vfi-edit-info-btn(ng-click='clickEdit()') Edit Information
 
   // Profile Body
@@ -21,20 +21,20 @@ div#profile-view(ng-controller="profileCtrl")
 
     div.vfi-tab-row
       button.vfi-profile-tab(ng-click="clickMilitaryTab()", ng-class="{'vfi-active' : currentTab=='military'}") Military Background
-      button.vfi-profile-tab(ng-click="clickFileClaimsTab()", ng-class="{'vfi-active' : currentTab=='file_claims'}") File Claims
+      button.vfi-profile-tab(ng-click="clickFileClaimsTab()", ng-class="{'vfi-active' : currentTab=='claims'}") File Claims
       button.vfi-profile-tab(ng-click="clickSettingsTab()", ng-class="{'vfi-active' : currentTab=='settings'}") Settings
 
 
     // Military Background
     div.vfi-profile-section#military(ng-if="currentTab=='military'")
-      div.vfi-section-header Military Information
+      h3.vfi-section-header Military Information
       div.vfi-section-content
         div.vfi-line Military Id
         div.vfi-line Date of Discharge
 
       div.vfi-section-divider
 
-      div.vfi-section-header Military Background
+      h3.vfi-section-header Military Background
       div.vfi-section-content.military-bg(ng-repeat='military in militaryInfo')
         img.vfi-insignia.army(ng-src='{{insigniaUrls[military.branch]}}')
         div.vfi-line {{ranks[military.rank]}}

--- a/winterfell/webapp/src/templates/tos.jade
+++ b/winterfell/webapp/src/templates/tos.jade
@@ -1,6 +1,6 @@
 #tos-view(ng-controller="tosCtrl")
     #tos-wrapper
-      div.vfi-title Terms of Service
+      h2.vfi-title Terms of Service
       div.vfi-tos-scroller
         p Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
         p Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.


### PR DESCRIPTION
Give h1, h2, h3, h4, h5 default sizings and remove margins
This way, we can use those heading elements and get the correct sizings for free.

There is also a Lead Paragraph which can be applied by using class .vfi-lead-p
otherwise, it will default to the body font sizings.

Measurements can be found here: https://standards.usa.gov/typography/