### PR TITLE
Make Biscuit Synchronous

### DIFF
--- a/winterfell/app.js
+++ b/winterfell/app.js
@@ -17,7 +17,17 @@ var biscuit = new Biscuit(app);
 
 app.environment = environment;
 app.baseUrl = Constants.baseUrl[app.environment];
-console.log('environment: ' + JSON.stringify(app.environment));
+
+// Setup biscuit keys
+function setupBiscuitKey(keyName) {
+  var yamlKey = Constants.biscuitKeys[keyName];
+  var secret = biscuit.get(environment + '::' + yamlKey);
+  app.set(keyName, secret);
+}
+
+setupBiscuitKey(Constants.KEY_LOB_API);
+setupBiscuitKey(Constants.KEY_IDME_CLIENT_ID);
+setupBiscuitKey(Constants.KEY_IDME_SECRET_ID);
 
 function loadIntoBuild (app, targetDir) {
   var normalizedPath = path.join(__dirname, targetDir);
@@ -32,6 +42,7 @@ loadIntoBuild(app, 'middlewares');
 loadIntoBuild(app, 'services');
 loadIntoBuild(app, 'controllers');
 
+
 // Serve static files
 app.use(express.static(path.join(__dirname, '/webapp/build')));
 app.get('/', function(req, resp) {
@@ -40,21 +51,6 @@ app.get('/', function(req, resp) {
 
 // Connect to a mongodb server using mongoose
 require('./config/mongoose')(environment);
-
-// Setup biscuit keys
-function setupBiscuitKey(keyName) {
-  var yamlKey = Constants.biscuitKeys[keyName];
-  biscuit.get(environment + '::' + yamlKey, function(err, secret) {
-    if (err) {
-      throw err;
-    }
-    app.set(keyName, secret);
-  });
-}
-
-setupBiscuitKey(Constants.KEY_LOB_API);
-setupBiscuitKey(Constants.KEY_IDME_CLIENT_ID);
-setupBiscuitKey(Constants.KEY_IDME_SECRET_ID);
 
 // Set address of document rendering microservice
 app.set('documentRenderingServiceAddress', documentRenderingConfig.address);

--- a/winterfell/services/biscuit.js
+++ b/winterfell/services/biscuit.js
@@ -1,16 +1,13 @@
-var exec = require('child_process').exec;
+var execSync = require('child_process').execSync;
 var BISCUIT_BIN='biscuit';
 
 function Biscuit (app) {
     this.secretsYamlFile = app.get('secretsFile');
 }
 
-Biscuit.prototype.get = function(secret, callback) {
+Biscuit.prototype.get = function(secret) {
     var command = BISCUIT_BIN + ' get -f ' + this.secretsYamlFile + ' \'' + secret + '\'';
-    exec(command,
-        function(err, stdout, stderr) {
-            callback(err, stdout);
-        });
+    return execSync(command, {encoding: 'utf8'});
 };
 
 module.exports = Biscuit;

--- a/winterfell/test/testBiscuit.js
+++ b/winterfell/test/testBiscuit.js
@@ -15,18 +15,16 @@ describe('Biscuit', function () {
     });
 
     it('should return secrets that exist', function(done) {
-        biscuit.get('test::secret', function(err, secret) {
-            should.not.exist(err);
-            secret.should.equal('stuff');
-            done();
-        });
+        var secret = biscuit.get('test::secret');
+        secret.should.equal('stuff');
+        done();
     });
 
 
     it('should error if secret does not exist', function(done) {
-        biscuit.get('test::not_in_yaml', function(err, secret) {
-            err.should.be.Error();
-            done();
-        });
+        should(function () {
+            biscuit.get('test::not_in_yaml')
+        }).throw(Error);
+        done();
     });
 });


### PR DESCRIPTION
Make biscuit synchronous so that the global app object contains them before the app starts. This fixes the problems with the unit tests.