### PR TITLE
Store Form Progress In DB

### DIFF
--- a/winterfell/config/mongoose.js
+++ b/winterfell/config/mongoose.js
@@ -1,4 +1,5 @@
 var mongoose = require('mongoose');
+mongoose.Promise = require('q').Promise;
 
 module.exports = function(environment) {
   var address = '0.0.0.0:27017'; // default

--- a/winterfell/controllers/claimController.js
+++ b/winterfell/controllers/claimController.js
@@ -10,7 +10,7 @@ var auth = require('../middlewares/auth');
 var _ = require('lodash');
 var bulk = require('bulk-require');
 var expressions = require("angular-expressions");
-var formlyFields = bulk('../webapp/src/forms/', ['*']);
+var formlyFields = bulk(__dirname + '/../forms/', ['*']);
 
 module.exports = function (app) {
 
@@ -160,11 +160,16 @@ module.exports = function (app) {
     var template = formlyFields[formName];
     var output = {answerable: 0, answered: _.size(data)};
 
+    if (!template) {
+      output.answerable = null;
+      return output;
+    }
+
     for (i = 0; i < template.fields.length; i++) {
       var field = template.fields[i];
       if (field.hasOwnProperty('hideExpression')) {
         evaluate = expressions.compile(field.hideExpression);
-        if (evaluate({model: data})) {
+        if (!evaluate({model: data})) {
           output.answerable += 1;
         }
       } else {

--- a/winterfell/controllers/claimController.js
+++ b/winterfell/controllers/claimController.js
@@ -57,10 +57,11 @@ module.exports = function (app) {
       }
     };
 
-
     User.findById(req.session.userId).exec(function (userErr, user) {
       if (user) {
-        ClaimService.findIncompleteClaimOrCreate(user._id, callback);
+        ClaimService.findIncompleteClaimOrCreate(user._id,
+          (req.body.forms || []),
+          callback);
       } else {
         res.status(http.NOT_FOUND).send({error: httpErrors.USER_NOT_FOUND});
       }

--- a/winterfell/forms/VBA-21-0966-ARE.json
+++ b/winterfell/forms/VBA-21-0966-ARE.json
@@ -49,7 +49,7 @@
         "email"
       ],
       "templateOptions": {
-        "label": "Your Email",
+        "label": "Your Email"
       }
     },
     {
@@ -242,7 +242,7 @@
         "state"
       ],
       "templateOptions": {
-        "label": "Veteran State",
+        "label": "Veteran State"
       }
     },
     {
@@ -252,7 +252,7 @@
         "zipCode"
       ],
       "templateOptions": {
-        "label": "Veteran Zipcode",
+        "label": "Veteran Zipcode"
       }
     },
     {

--- a/winterfell/models/form.js
+++ b/winterfell/models/form.js
@@ -8,7 +8,9 @@ var formSchema = new Schema({
   key: String, // Code name for the form
   responses: Schema.Types.Mixed,
   user: Schema.Types.ObjectId,
-  claim: Schema.Types.ObjectId
+  claim: Schema.Types.ObjectId,
+  answered: Schema.Types.Integer,
+  answerable: Schema.Types.Integer
 }, {
   timestamps: true
 });

--- a/winterfell/models/form.js
+++ b/winterfell/models/form.js
@@ -9,8 +9,8 @@ var formSchema = new Schema({
   responses: Schema.Types.Mixed,
   user: Schema.Types.ObjectId,
   claim: Schema.Types.ObjectId,
-  answered: Schema.Types.Integer,
-  answerable: Schema.Types.Integer
+  answered: Number,
+  answerable: Number
 }, {
   timestamps: true
 });

--- a/winterfell/package.json
+++ b/winterfell/package.json
@@ -12,6 +12,7 @@
     "@iamadamjowett/angular-click-outside": "^2.8.3",
     "angular": "^1.5.8",
     "angular-cookies": "^1.5.8",
+    "angular-expressions": "^0.3.0",
     "angular-formly": "^8.3.0",
     "angular-ui-router": "^0.3.1",
     "api-check": "^7.5.5",

--- a/winterfell/services/claimService.js
+++ b/winterfell/services/claimService.js
@@ -12,6 +12,8 @@ function ClaimService(app) {
   this.app = app;
 }
 
+module.exports = ClaimService;
+
 /**
  * For a given form and set of responses, calculate how many questions
  * were answered (which is simply the number of keys in the responses),
@@ -19,13 +21,16 @@ function ClaimService(app) {
  * which requires evaluating the angular hideExpression attribute for
  * each field against the current responses.
  *
- * @param formName
+ * @param formId
  * @param data
  * @returns {{answerable: number, answered: number}}
  */
-function calculateProgress(formName, data) {
+module.exports.calculateProgress = function calculateProgress(formId, data) {
   var evaluate, i;
-  var template = formlyFields[formName];
+  if (!(formId in formlyFields)) {
+    throw new Error("Unknown formId: " + formId);
+  }
+  var template = formlyFields[formId];
   var output = {answerable: 0, answered: _.size(data)};
 
   if (!template) {
@@ -46,11 +51,8 @@ function calculateProgress(formName, data) {
   }
 
   return output;
-}
+};
 
-module.exports.calculateProgress = calculateProgress;
-
-module.exports = ClaimService;
 module.exports.findIncompleteClaimOrCreate = function(userId, forms, callback) {
   return Claim.findOne({ userId: userId, state: Claim.State.INCOMPLETE }).exec(function(err, fileClaim) {
     if (err) {

--- a/winterfell/services/claimService.js
+++ b/winterfell/services/claimService.js
@@ -14,8 +14,8 @@ function ClaimService(app) {
 
 /**
  * For a given form and set of responses, calculate how many questions
- * were answered (which is simply then number of keys in the responses),
- * and more complicatedly, how many questions on the form were answerable,
+ * were answered (which is simply the number of keys in the responses),
+ * and more complicatedly: how many questions on the form were answerable,
  * which requires evaluating the angular hideExpression attribute for
  * each field against the current responses.
  *
@@ -61,7 +61,7 @@ module.exports.findIncompleteClaimOrCreate = function(userId, forms, callback) {
           callback(err, null);
           return;
         }
-        // Create all the forms and dont call the callback
+        // Create all the forms and don't call the callback
         // until this is done by using a promise chain.
         var promise = Q();
         forms.forEach(function(form) {

--- a/winterfell/services/claimService.js
+++ b/winterfell/services/claimService.js
@@ -2,18 +2,40 @@ var _ = require('lodash');
 var http = require('http-status-codes');
 var httpErrors = require('./../utils/httpErrors');
 var Claim = require('./../models/claim');
+var Form = require('./../models/form');
+var Q = require('q');
+var mongoose = require('mongoose');
+mongoose.Promise = Q.Promise;
 
 function ClaimService(app) {
   this.app = app;
 }
 
 module.exports = ClaimService;
-module.exports.findIncompleteClaimOrCreate = function(userId, callback) {
+module.exports.findIncompleteClaimOrCreate = function(userId, forms, callback) {
   return Claim.findOne({ userId: userId, state: Claim.State.INCOMPLETE }).exec(function(err, fileClaim) {
     if (err) {
       callback(err, null);
     } else if (_.isEmpty(fileClaim)) {
-      Claim.quickCreate(userId, callback);
+      Claim.quickCreate(userId, function (err, claim) {
+        var promise = Q();
+        forms.forEach(function(form) {
+          promise.then(function() {
+            return Form.create({
+              key: form,
+              user: userId,
+              responses: {},
+              claim: claim._id
+            });
+          })
+        });
+        promise.then(function() {
+          callback(null, claim);
+        });
+        promise.catch(function() {
+          callback(err, null);
+        })
+      })
     } else {
       callback(null, fileClaim)
     }

--- a/winterfell/test/testClaimController.js
+++ b/winterfell/test/testClaimController.js
@@ -211,6 +211,7 @@ describe('SaveClaimController', function () {
       .expect(201, function() {
         Form.findOne({key: '1', user: targetUser._id}, function(error, doc) {
           should.not.exist(error);
+          should.exist(doc);
           doc.responses.should.deepEqual({key1: 'value1', key2: 'value2'});
           done();
         })
@@ -219,13 +220,29 @@ describe('SaveClaimController', function () {
 
   it('Should correctly calculate progress after save', function(done) {
     testSession
-      .post('/save/' + targetClaim._id + '/1')
+      .post('/save/' + targetClaim._id + '/VBA-21-0966-ARE')
       .send({filing_for_self: false})
       .expect(201, function() {
-        Form.findOne({key: '1', user: targetUser._id}, function(error, doc) {
+        Form.findOne({key: 'VBA-21-0966-ARE', user: targetUser._id}, function(error, doc) {
           should.not.exist(error);
+          should.exist(doc);
           doc.answered.should.be.exactly(1);
-          doc.answerable.should.be.exactly(23);
+          doc.answerable.should.be.exactly(27);
+          done();
+        })
+      })
+  });
+
+  it('Should correctly calculate progress after save with hidden questions', function(done) {
+    testSession
+      .post('/save/' + targetClaim._id + '/VBA-21-0966-ARE')
+      .send({filing_for_self: true})
+      .expect(201, function() {
+        Form.findOne({key: 'VBA-21-0966-ARE', user: targetUser._id}, function(error, doc) {
+          should.not.exist(error);
+          should.exist(doc);
+          doc.answered.should.be.exactly(1);
+          doc.answerable.should.be.exactly(22);
           done();
         })
       })

--- a/winterfell/test/testClaimController.js
+++ b/winterfell/test/testClaimController.js
@@ -206,10 +206,10 @@ describe('SaveClaimController', function () {
 
   it('Should save the claim form after signin', function(done) {
     testSession
-      .post('/save/' + targetClaim._id + '/1')
+      .post('/save/' + targetClaim._id + '/VBA-21-0966-ARE')
       .send({key1: 'value1', key2: 'value2'})
       .expect(201, function() {
-        Form.findOne({key: '1', user: targetUser._id}, function(error, doc) {
+        Form.findOne({key: 'VBA-21-0966-ARE', user: targetUser._id}, function(error, doc) {
           should.not.exist(error);
           should.exist(doc);
           doc.responses.should.deepEqual({key1: 'value1', key2: 'value2'});

--- a/winterfell/test/testClaimController.js
+++ b/winterfell/test/testClaimController.js
@@ -9,6 +9,7 @@ var UserValues = require('../models/userValues');
 var UserService = require('./../services/userService');
 var session = require('supertest-session');
 var uuid = require('uuid');
+var claimController = require('./../controllers/claimController.js');
 
 describe('ClaimController', function() {
   var targetUser;
@@ -214,5 +215,19 @@ describe('SaveClaimController', function () {
           done();
         })
       });
+  });
+
+  it('Should correctly calculate progress after save', function(done) {
+    testSession
+      .post('/save/' + targetClaim._id + '/1')
+      .send({filing_for_self: false})
+      .expect(201, function() {
+        Form.findOne({key: '1', user: targetUser._id}, function(error, doc) {
+          should.not.exist(error);
+          doc.answered.should.be.exactly(1);
+          doc.answerable.should.be.exactly(23);
+          done();
+        })
+      })
   });
 });

--- a/winterfell/test/testClaimService.js
+++ b/winterfell/test/testClaimService.js
@@ -11,7 +11,6 @@ describe('ClaimService', function() {
   var server, targetUser;
 
   before(function (done) {
-    this.timeout(10000);
     server = require('../app');
 
     // Remove all users and create one user
@@ -84,10 +83,10 @@ describe('ClaimService', function() {
   });
 
   it('Create claim with forms', function (done) {
-    ClaimService.findIncompleteClaimOrCreate(targetUser._id, ['a', 'b', 'c'], function (err, claim) {
+    ClaimService.findIncompleteClaimOrCreate(targetUser._id, ['VBA-21-0966-ARE'], function (err, claim) {
       Form.find({claim: claim._id}, function (err, forms) {
         Boolean(err).should.equal(false);
-        forms.length.should.be.exactly(3);
+        forms.length.should.be.exactly(1);
         done();
       });
     });

--- a/winterfell/test/testClaimService.js
+++ b/winterfell/test/testClaimService.js
@@ -5,6 +5,8 @@ var Claim = require('../models/claim');
 var ClaimService = require('../services/claimService');
 var User = require('../models/user');
 var UserService = require('../services/userService');
+var Form = require('../models/form');
+
 
 describe('ClaimService', function() {
   var targetUser = undefined;
@@ -36,7 +38,7 @@ describe('ClaimService', function() {
       state: Claim.State.INCOMPLETE
     });
     existingClaim.save(function(err, claim) {
-      ClaimService.findIncompleteClaimOrCreate(targetUser._id, function(err, claim) {
+      ClaimService.findIncompleteClaimOrCreate(targetUser._id, [], function(err, claim) {
         Boolean(err).should.equal(false);
         Boolean(claim).should.equal(true);
         done();
@@ -45,7 +47,7 @@ describe('ClaimService', function() {
   });
 
   it('Create new INCOMPLETE Claim - success', function(done) {
-    ClaimService.findIncompleteClaimOrCreate(targetUser._id, function(err, claim) {
+    ClaimService.findIncompleteClaimOrCreate(targetUser._id, [], function(err, claim) {
       Boolean(err).should.equal(false);
       claim.userId.should.equal(targetUser._id);
       claim.state.should.equal(Claim.State.INCOMPLETE);
@@ -54,7 +56,7 @@ describe('ClaimService', function() {
   });
 
   it('Set Claim state to SUBMITTED', function(done) {
-    ClaimService.findIncompleteClaimOrCreate(targetUser._id, function(err, claim) {
+    ClaimService.findIncompleteClaimOrCreate(targetUser._id, [], function(err, claim) {
       ClaimService.setClaimState(claim._id, Claim.State.SUBMITTED, function(err, update) {
         Boolean(err).should.equal(false);
         update.ok.should.equal(1);
@@ -67,7 +69,7 @@ describe('ClaimService', function() {
   });
 
   it('Set Claim state to DISCARDED', function(done) {
-    ClaimService.findIncompleteClaimOrCreate(targetUser._id, function(err, claim) {
+    ClaimService.findIncompleteClaimOrCreate(targetUser._id, [], function(err, claim) {
       ClaimService.setClaimState(claim._id, Claim.State.DISCARDED, function(err, update) {
         Boolean(err).should.equal(false);
         update.ok.should.equal(1);
@@ -79,8 +81,13 @@ describe('ClaimService', function() {
     });
   });
 
-  xit('Add form to claim', function(done) {
-
+  it('Create claim with forms', function (done) {
+    ClaimService.findIncompleteClaimOrCreate(targetUser._id, ['a', 'b', 'c'], function (err, claim) {
+      Form.find({claim: claim._id}, function (err, forms) {
+        forms.length.should.be.exactly(3);
+        done();
+      });
+    });
   });
 
   xit('Remove form from claim', function(done) {

--- a/winterfell/test/testClaimService.js
+++ b/winterfell/test/testClaimService.js
@@ -7,26 +7,28 @@ var User = require('../models/user');
 var UserService = require('../services/userService');
 var Form = require('../models/form');
 
-
 describe('ClaimService', function() {
-  var targetUser = undefined;
+  var server, targetUser;
 
-  before(function(done) {
-     // Remove all users and create one user
-     User.remove({}, function() {
-       var user = {
-         firstname: 'User1',
-         lastname: 'McUser',
-         email: 'user1@email.com',
-         password: 'testword',
-         state: User.State.ACTIVE
-       };
-       User.create(user, function(err, user) {
-         targetUser = user;
-         done();
-       });
-     });
-   });
+  before(function (done) {
+    this.timeout(10000);
+    server = require('../app');
+
+    // Remove all users and create one user
+    User.remove({}, function () {
+      var user = {
+        firstname: 'User1',
+        lastname: 'McUser',
+        email: 'user1@email.com',
+        password: 'testword',
+        state: User.State.ACTIVE
+      };
+      User.create(user, function (err, user) {
+        targetUser = user;
+        done();
+      });
+    });
+  });
 
   beforeEach(function(done) {
     Claim.remove({}, done);
@@ -84,6 +86,7 @@ describe('ClaimService', function() {
   it('Create claim with forms', function (done) {
     ClaimService.findIncompleteClaimOrCreate(targetUser._id, ['a', 'b', 'c'], function (err, claim) {
       Form.find({claim: claim._id}, function (err, forms) {
+        Boolean(err).should.equal(false);
         forms.length.should.be.exactly(3);
         done();
       });

--- a/winterfell/webapp/src/js/app.js
+++ b/winterfell/webapp/src/js/app.js
@@ -96,7 +96,22 @@ app.config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $u
     name: 'root.claimselect',
     url: '/claim/{claimId}/select-forms',
     templateUrl: 'templates/claimSelectForms.html',
-    controller: 'claimSelectFormsCtrl'
+    controller: 'claimSelectFormsCtrl',
+    resolve: {
+      forms: ['net', '$q', '$stateParams', function(net, $q, $stateParams) {
+        var deferred = $q.defer();
+
+        net.getFormsForUser($stateParams.claimId).then(
+          function success(res) {
+            deferred.resolve(res.data);
+          }, function failure(res) {
+            deferred.reject();
+          }
+        );
+
+        return deferred.promise;
+      }]
+    }
   });
 
   $stateProvider.state({

--- a/winterfell/webapp/src/js/app.js
+++ b/winterfell/webapp/src/js/app.js
@@ -101,7 +101,7 @@ app.config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $u
       forms: ['net', '$q', '$stateParams', function(net, $q, $stateParams) {
         var deferred = $q.defer();
 
-        net.getFormsForUser($stateParams.claimId).then(
+        net.getFormsForClaim($stateParams.claimId).then(
           function success(res) {
             deferred.resolve(res.data);
           }, function failure(res) {

--- a/winterfell/webapp/src/js/claimSelectFormsCtrl.js
+++ b/winterfell/webapp/src/js/claimSelectFormsCtrl.js
@@ -1,55 +1,11 @@
 var app = angular.module('vetafiApp');
-app.controller('claimSelectFormsCtrl', ['$scope', '$state', '$stateParams', 'claimService', 'formTemplateService',
-  function($scope, $state, $stateParams, claimService, formTemplateService) {
+app.controller('claimSelectFormsCtrl', ['$scope', 'claimService', 'formTemplateService', '$stateParams', 'forms',
+  function($scope, claimService, formTemplateService, $stateParams, forms) {
     $scope.claimId = $stateParams.claimId;
-
-    $scope.allForms = formTemplateService; // returns an object {formId -> {...}}
-    var userForms = {};                    // should be {formId -> {...}}
-    // TODO: state of all forms edited by user
-    // var userForms = {
-    //   'VBA-21-0966-ARE': {
-    //      state: 'complete'
-    //   }
-    // };
-    $scope.requiredForms = [];
-    $scope.optionalForms = [];
-    $scope.numRequiredCompleted = 0;
-    $scope.progressBarType = undefined;
-
-    function partitionAllForms() {
-      var partitionForms = _.partition($scope.allForms, 'required');
-      $scope.requiredForms = partitionForms[0];
-      $scope.optionalForms = partitionForms[1];
-    }
-
-    function calcFormState(state, required) {
-      if (state == 'complete') {
-        return 'complete';
-      } else if (required) {
-        return 'required_incomplete';
-      } else {
-        return 'incomplete';
-      }
-    }
-
-    function calcFormsCompleted() {
-      var numRequiredCompleted = 0;
-
-      _.map(_.keys($scope.allForms), function(formId) {
-        var targetForm = $scope.allForms[formId];
-        var userForm = userForms[formId];
-        var userFormState = userForm ? userForm.state : 'incomplete';
-        targetForm.id = formId;
-        targetForm.state = calcFormState(userFormState, targetForm.required);
-
-        if (targetForm.required && targetForm.state == 'complete') {
-          numRequiredCompleted++;
-        }
-      });
-
-      $scope.numRequiredCompleted = numRequiredCompleted;
-      $scope.progressBarType = $scope.numRequiredCompleted == $scope.requiredForms.length ? 'success' : undefined;
-    }
+    $scope.formOptions = formTemplateService;
+    $scope.formState = _.keyBy(forms, function(form) {
+      return form.key;
+    });
 
     $scope.onClickCancel = function() {
       console.log("Are you sure you want to cancel? You will have to start over if you do. Y/N?");

--- a/winterfell/webapp/src/js/claimSelectFormsCtrl.js
+++ b/winterfell/webapp/src/js/claimSelectFormsCtrl.js
@@ -10,7 +10,6 @@ app.controller('claimSelectFormsCtrl', ['$scope', 'claimService', 'formTemplateS
     $scope.numRequiredCompleted = _.sum(_.map(forms, function (form) {
       return form.answered == form.answerable ? 1 : 0;
     }));
-
     $scope.numRequiredForms = forms.length;
 
     $scope.onClickCancel = function() {

--- a/winterfell/webapp/src/js/claimSelectFormsCtrl.js
+++ b/winterfell/webapp/src/js/claimSelectFormsCtrl.js
@@ -2,10 +2,16 @@ var app = angular.module('vetafiApp');
 app.controller('claimSelectFormsCtrl', ['$scope', 'claimService', 'formTemplateService', '$stateParams', 'forms',
   function($scope, claimService, formTemplateService, $stateParams, forms) {
     $scope.claimId = $stateParams.claimId;
-    $scope.formOptions = formTemplateService;
-    $scope.formState = _.keyBy(forms, function(form) {
+    $scope.formTemplates = formTemplateService;
+    $scope.forms = _.keyBy(forms, function(form) {
       return form.key;
     });
+
+    $scope.numRequiredCompleted = _.sum(_.map(forms, function (form) {
+      return form.answered == form.answerable ? 1 : 0;
+    }));
+
+    $scope.numRequiredForms = forms.length;
 
     $scope.onClickCancel = function() {
       console.log("Are you sure you want to cancel? You will have to start over if you do. Y/N?");
@@ -15,8 +21,5 @@ app.controller('claimSelectFormsCtrl', ['$scope', 'claimService', 'formTemplateS
     $scope.onClickDone = function() {
       console.log("Verifying things are correct...");
     };
-
-    partitionAllForms();
-    calcFormsCompleted();
   }
 ]);

--- a/winterfell/webapp/src/js/claimStartCtrl.js
+++ b/winterfell/webapp/src/js/claimStartCtrl.js
@@ -14,7 +14,9 @@ app.controller('claimStartCtrl', ['$scope', '$state', 'net', 'claimService', '$u
           return;
         }
       }
-      net.startClaim().then(function (res) {
+      net.startClaim(
+        {forms: ["VBA-21-0966-ARE"]} // hardcoded to create claim with only this form for now
+      ).then(function (res) {
         $state.transitionTo('root.claimselect', {claimId: res.data.claim.externalId});
       });
     };

--- a/winterfell/webapp/src/js/formCtrl.js
+++ b/winterfell/webapp/src/js/formCtrl.js
@@ -3,10 +3,17 @@
  */
 'use strict';
 var app = angular.module('vetafiApp');
-app.controller('formCtrl',
-  ['$scope', '$filter', '$rootScope', 'formRenderingService', 'formTemplateService', 'formService', '$stateParams', 'userValues',
-    function ($scope, $filter, $rootScope, formRenderingService, formTemplateService, formService, $stateParams, userValues) {
-      $scope.formId = $stateParams.formId;
+
+app.controller('formCtrl', ['$scope', '$filter', '$rootScope', 'formRenderingService', 'formTemplateService',
+    'formService', '$stateParams', '$state', 'userValues',
+    function ($scope, $filter, $rootScope, formRenderingService, formTemplateService, formService,
+              $stateParams, $state, userValues) {
+        $scope.$watch('signature', function (newVal, oldVal) {
+            console.log(newVal, oldVal);
+            if (newVal) {
+                $scope.model['signature'] = newVal.dataUrl;
+            }
+        });
 
       $scope.$watch('dataurl', function (newVal, oldVal) {
         console.log(newVal, oldVal);
@@ -32,11 +39,8 @@ app.controller('formCtrl',
       };
 
       $scope.onSubmit = function () {
-        console.log($scope.fields);
-        console.log($scope.model);
-
-        //$scope.render();
-        console.log($scope);
+          $scope.save();
+          $state.transitionTo('root.claimselect', {claimId: $stateParams.claimId});
       };
 
       $scope.save = function () {

--- a/winterfell/webapp/src/js/net.js
+++ b/winterfell/webapp/src/js/net.js
@@ -68,7 +68,7 @@ app.factory('net', ['xhrEnv', '$http', function(xhrEnv, $http) {
     discardClaim: function(extClaimId) {
       return httpDelete("/claim/" + extClaimId);
     },
-    getFormsForUser: function(extClaimId) {
+    getFormsForClaim: function(extClaimId) {
       return httpGet("/claim/" + extClaimId + "/forms");
     }
   };

--- a/winterfell/webapp/src/js/net.js
+++ b/winterfell/webapp/src/js/net.js
@@ -59,14 +59,17 @@ app.factory('net', ['xhrEnv', '$http', function(xhrEnv, $http) {
     getClaimsForUser: function() {
       return httpGet("/claims");
     },
-    startClaim: function() {
-      return httpPost("/claims/create");
+    startClaim: function(data) {
+      return httpPost("/claims/create", data);
     },
     submitClaim: function(extClaimId) {
       return httpPost("/claim/" + extClaimId + "/submit");
     },
     discardClaim: function(extClaimId) {
       return httpDelete("/claim/" + extClaimId);
+    },
+    getFormsForUser: function(extClaimId) {
+      return httpGet("/claim/" + extClaimId + "/forms");
     }
   };
 }]);

--- a/winterfell/webapp/src/styles/form.styl
+++ b/winterfell/webapp/src/styles/form.styl
@@ -1,3 +1,5 @@
+@import "standards.styl"
+
 .signature-success
   color: #3c763d
 
@@ -19,6 +21,7 @@
   border-bottom-style: dotted
   position: relative
   background-color: white
+  cursor: default
 
   & canvas
     padding: 0;
@@ -61,3 +64,7 @@
 
 .floating-progress-text
   text-align: end
+
+.disabled
+  background-color: colorLightGray
+  cursor: not-allowed !important

--- a/winterfell/webapp/src/templates/claimSelectForms.jade
+++ b/winterfell/webapp/src/templates/claimSelectForms.jade
@@ -1,25 +1,26 @@
 #select-forms-view
   vfi-breadcrumbs(page="1")
+<<<<<<< HEAD
   #select-forms-wrapper
     h3 Select Forms for Claim
 
     div.section.required
       div.section-header
         h4 Required Forms:
-        uib-progressbar.progressbar(value="numRequiredCompleted", max="requiredForms.length", type="{{progressBarType}}")
-          span {{numRequiredCompleted}}/{{requiredForms.length}}
+        uib-progressbar.progressbar(value="numRequiredCompleted", max="numRequiredForms", type="{{progressBarType}}")
+          span {{numRequiredCompleted}}/{{numRequiredForms}}
 
-      div.form-wrapper(ng-repeat="form in requiredForms")
+      div.form-wrapper(ng-repeat="(formId, form) in forms")
         div.form-content
           div.state-wrapper(ng-class="{'required': form.state=='required_incomplete', 'complete': form.state=='complete'}")
             div.state-icon
           div.form-title-wrapper
             h5.title(ng-class="{'required': form.state=='required_incomplete'}") {{form.id}}
             h5.warning.required(ng-if="form.state=='required_incomplete'") &nbsp;(required)
-            h5.subtitle {{form.unofficialTitle}}
-          div.form-summary {{form.unofficialDescription}}
+            h5.subtitle {{formTemplates[form.key].unofficialTitle}}
+          div.form-summary {{formTemplates[form.key].unofficialDescription}}
         div.form-buttons
-          button.edit-btn(ui-sref="root.form({claimId: claimId, formId: form.id})")
+          button.edit-btn(ui-sref="root.form({claimId: claimId, formId: formId})")
             div.edit-icon
             | Edit
           button.download-btn
@@ -28,7 +29,7 @@
 
     div.button-wrapper
       button.cancel-btn Cancel
-      button.done-btn(ng-class="{'ready':numRequiredCompleted == requiredForms.length}") Done
+      button.done-btn(ng-class="{'ready':numRequiredCompleted == numRequiredForms}") Done
       div.clearer
 
 vfi-footer

--- a/winterfell/webapp/src/templates/claimSelectForms.jade
+++ b/winterfell/webapp/src/templates/claimSelectForms.jade
@@ -6,7 +6,7 @@
     div.section.required
       div.section-header
         h4 Required Forms:
-        uib-progressbar.progressbar(value="numRequiredCompleted", max="numRequiredForms", type="{{progressBarType}}")
+        uib-progressbar.progressbar(value="numRequiredCompleted", max="numRequiredForms", type="{{numRequiredCompleted == numRequiredForms ? 'success' : 'info'}}")
           span {{numRequiredCompleted}}/{{numRequiredForms}}
 
       div.form-wrapper(ng-repeat="(formId, form) in forms")

--- a/winterfell/webapp/src/templates/claimSelectForms.jade
+++ b/winterfell/webapp/src/templates/claimSelectForms.jade
@@ -1,6 +1,5 @@
 #select-forms-view
   vfi-breadcrumbs(page="1")
-<<<<<<< HEAD
   #select-forms-wrapper
     h3 Select Forms for Claim
 
@@ -12,11 +11,11 @@
 
       div.form-wrapper(ng-repeat="(formId, form) in forms")
         div.form-content
-          div.state-wrapper(ng-class="{'required': form.state=='required_incomplete', 'complete': form.state=='complete'}")
+          div.state-wrapper(ng-class="{'required': formTemplates[form.key].required, 'complete': form.answered == form.answerable}")
             div.state-icon
           div.form-title-wrapper
-            h5.title(ng-class="{'required': form.state=='required_incomplete'}") {{form.id}}
-            h5.warning.required(ng-if="form.state=='required_incomplete'") &nbsp;(required)
+            h5.title(ng-class="{'required': formTemplates[form.key].required}") {{form.id}}
+            h5.warning.required(ng-if="form.state == formTemplates[form.key].required") &nbsp;(required)
             h5.subtitle {{formTemplates[form.key].unofficialTitle}}
           div.form-summary {{formTemplates[form.key].unofficialDescription}}
         div.form-buttons

--- a/winterfell/webapp/src/templates/form.jade
+++ b/winterfell/webapp/src/templates/form.jade
@@ -17,7 +17,7 @@ div#vfi-form-view
                     | Clear Signature
 
         div.row.form-submit-button-group
-            button(type="submit")
+            button(type="submit" ng-class="{'disabled': answered != answerable}")
                 | Submit
             button(ng-click="render()")
                 | Download


### PR DESCRIPTION
- Stores number of answered/answerable questions along with each form so we can show total claim progress
- Calculate progress of each form on the backend by executing business logic of which questions are answerable/answered. We use the same logic we use on the frontend to tell the user in realtime their progress by using the angular-expressions library in the backend to evaluate the same conditionals that determine whether a question needs to be answered.
- The claim creation endpoint is now a post that takes a list of forms, and those forms will be initialized along with the claim
- The claim select page now resolves the forms via the ui router so that the progress can be displayed (haven't updated the template to actually display it yet though).