### PR TITLE
Use autocomplete Attribute for Form Elements

### DIFF
--- a/winterfell/forms/VBA-21-0966-ARE.json
+++ b/winterfell/forms/VBA-21-0966-ARE.json
@@ -49,7 +49,8 @@
         "email"
       ],
       "templateOptions": {
-        "label": "Your Email"
+        "label": "Your Email",
+        "autocomplete": "email"
       }
     },
     {
@@ -157,7 +158,8 @@
       "type": "input",
       "templateOptions": {
         "label": "First Name",
-        "placeholder": "John"
+        "placeholder": "John",
+        "autocomplete": "given-name"
       }
     },
     {
@@ -165,7 +167,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Middle Initial",
-        "placeholder": "C"
+        "placeholder": "C",
+        "autocomplete": "additional-name"
       }
     },
     {
@@ -173,7 +176,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Last Name",
-        "placeholder": "Doe"
+        "placeholder": "Doe",
+        "autocomplete": "family-name"
       }
     },
     {
@@ -181,7 +185,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Claimant's First Name",
-        "placeholder": "John"
+        "placeholder": "John",
+        "autocomplete": "given-name"
       },
       "hideExpression": "model.filing_for_self"
     },
@@ -190,7 +195,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Claimant's Middle Initial",
-        "placeholder": "C"
+        "placeholder": "C",
+        "autocomplete": "additional-name"
       },
       "hideExpression": "model.filing_for_self"
     },
@@ -199,7 +205,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Claimant's Last Name",
-        "placeholder": "Doe"
+        "placeholder": "Doe",
+        "autocomplete": "family-name"
       },
       "hideExpression": "model.filing_for_self"
     },
@@ -208,7 +215,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Veteran Address Line 1",
-        "placeholder": "55 Magnolia St."
+        "placeholder": "55 Magnolia St.",
+        "autocomplete": "address-line1"
       }
     },
     {
@@ -216,7 +224,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Veteran Address Line 2",
-        "placeholder": ""
+        "placeholder": "",
+        "autocomplete": "address-line2"
       }
     },
     {
@@ -224,7 +233,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Veteran Apartment Number",
-        "placeholder": "Name"
+        "placeholder": "Name",
+        "autocomplete": "address-line3"
       }
     },
     {
@@ -232,7 +242,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Veteran City",
-        "placeholder": ""
+        "placeholder": "",
+        "autocomplete": "address-level2"
       }
     },
     {
@@ -242,7 +253,8 @@
         "state"
       ],
       "templateOptions": {
-        "label": "Veteran State"
+        "label": "Veteran State",
+        "autocomplete": "address-level1"
       }
     },
     {
@@ -252,7 +264,8 @@
         "zipCode"
       ],
       "templateOptions": {
-        "label": "Veteran Zipcode"
+        "label": "Veteran Zipcode",
+        "autocomplete": "postal-code"
       }
     },
     {
@@ -260,7 +273,8 @@
       "type": "input",
       "templateOptions": {
         "label": "Veteran Country",
-        "placeholder": "USA"
+        "placeholder": "USA",
+        "autocomplete": "country-name"
       }
     },
     {
@@ -270,7 +284,8 @@
         "phoneNumber"
       ],
       "templateOptions": {
-        "label": "Your Phone Number"
+        "label": "Your Phone Number",
+        "autocomplete": "tel"
       }
     },
     {
@@ -289,7 +304,8 @@
       ],
       "templateOptions": {
         "label": "Veteran Date of Birth",
-        "placeholder": "MM/DD/YYYY"
+        "placeholder": "MM/DD/YYYY",
+        "autocomplete": "bday"
       }
     },
     {

--- a/winterfell/webapp/src/libs/formly.js
+++ b/winterfell/webapp/src/libs/formly.js
@@ -1,5 +1,5 @@
 /*!
-* angular-formly JavaScript Library v8.3.0
+* angular-formly JavaScript Library v0.0.0-semantically-released.0
 *
 * @license MIT (http://license.angular-formly.com)
 *
@@ -157,7 +157,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	ngModule.constant('formlyApiCheck', _providersFormlyApiCheck2['default']);
 	ngModule.constant('formlyErrorAndWarningsUrlPrefix', _otherDocsBaseUrl2['default']);
-	ngModule.constant('formlyVersion', ("8.3.0")); // <-- webpack variable
+	ngModule.constant('formlyVersion', ("0.0.0-semantically-released.0")); // <-- webpack variable
 
 	ngModule.provider('formlyUsability', _providersFormlyUsability2['default']);
 	ngModule.provider('formlyConfig', _providersFormlyConfig2['default']);
@@ -367,6 +367,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  resetModel: apiCheck.func.optional,
 	  updateInitialValue: apiCheck.func.optional,
 	  removeChromeAutoComplete: apiCheck.bool.optional,
+	  parseKeyArrays: apiCheck.bool.optional,
 	  templateManipulators: templateManipulators.optional,
 	  manualModelWatcher: apiCheck.oneOfType([apiCheck.bool, apiCheck.func]).optional,
 	  watchAllExpressions: apiCheck.bool.optional,
@@ -435,7 +436,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	Object.defineProperty(exports, "__esModule", {
 	  value: true
 	});
-	exports["default"] = "https://github.com/formly-js/angular-formly/blob/" + ("8.3.0") + "/other/ERRORS_AND_WARNINGS.md#";
+	exports["default"] = "https://github.com/formly-js/angular-formly/blob/" + ("0.0.0-semantically-released.0") + "/other/ERRORS_AND_WARNINGS.md#";
 	module.exports = exports["default"];
 
 /***/ },
@@ -564,6 +565,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      fieldTransform: [],
 	      ngModelAttrsManipulatorPreferUnbound: false,
 	      removeChromeAutoComplete: false,
+	      parseKeyArrays: false,
 	      defaultHideDirective: 'ng-if',
 	      getFieldId: null
 	    },
@@ -1249,7 +1251,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // @ngInject
 	  function FormlyFieldController($scope, $timeout, $parse, $controller, formlyValidationMessages) {
-	    /* eslint max-statements:[2, 34] */
+	    /* eslint max-statements:[2, 37] */
 	    if ($scope.options.fieldGroup) {
 	      setupFieldGroup();
 	      return;
@@ -1324,6 +1326,25 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return _angularFix2['default'].isNumber(key) || !formlyUtil.containsSelector(key);
 	    }
 
+	    function keyContainsArrays(key) {
+	      return (/\[\d{1,}\]/.test(key)
+	      );
+	    }
+
+	    function deepAssign(obj, prop, value) {
+	      if (_angularFix2['default'].isString(prop)) {
+	        prop = prop.replace(/\[(\w+)\]/g, '.$1').split('.');
+	      }
+
+	      if (prop.length > 1) {
+	        var e = prop.shift();
+	        obj[e] = obj[e] || isNaN(prop[0]) ? {} : [];
+	        deepAssign(obj[e], prop, value);
+	      } else {
+	        obj[prop[0]] = value;
+	      }
+	    }
+
 	    function parseSet(key, model, newVal) {
 	      // If either of these are null/undefined then just return undefined
 	      if (!key && key !== 0 || !model) {
@@ -1333,6 +1354,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      if (shouldNotUseParseKey(key)) {
 	        // TODO: Fix this so we can get several levels instead of just one with properties that are numeric
 	        model[key] = newVal;
+	      } else if (formlyConfig.extras.parseKeyArrays && keyContainsArrays(key)) {
+	        deepAssign($scope.model, key, newVal);
 	      } else {
 	        var setter = $parse($scope.options.key).assign;
 	        if (setter) {
@@ -2712,7 +2735,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	    var bothBooleanAndBound = ['required', 'disabled'];
 	    var bothAttributeAndBound = ['pattern', 'minlength'];
 	    var statementOnly = ['change', 'keydown', 'keyup', 'keypress', 'click', 'focus', 'blur'];
-	    var attributeOnly = ['placeholder', 'min', 'max', 'step', 'tabindex', 'type'];
+	    var attributeOnly = ['placeholder', 'min', 'max', 'step', 'tabindex', 'type', 'autocomplete'];
 	    if (formlyConfig.extras.ngModelAttrsManipulatorPreferUnbound) {
 	      bothAttributeAndBound.push('maxlength');
 	    } else {


### PR DESCRIPTION
The `autocomplete` attribute gives us control over the way browsers will fill in our forms (https://html.spec.whatwg.org/multipage/forms.html).

In this revision I have modified the formly library to allow passing an `autocomplete` parameter, and updated the form template to provide it for elements where it makes sense.

I plan to submit my change as a pull request to the formly js project, but I am just modifying the library code in-place for now. I like that we have our dependencies checked in, which allows us to modify our libraries like this when needed.