### PR TITLE
Fix CSRF In Tests

### DIFF
--- a/winterfell/controllers/authController.js
+++ b/winterfell/controllers/authController.js
@@ -93,16 +93,15 @@ module.exports = function (app) {
   // Endpoint to authenticate logins and begin session
   app.post('/api/auth/login',
     passport.authenticate('local', {
-      successRedirect: '/',
       failureRedirect: '/login?error=EAUTHFAILED'
       }),
     function(req, res) {
-    if (req.user) {
-      req.session.key = req.body.email;
-      req.session.userId = req.user._id;
-      var extUserId = req.user.externalId;
-      res.status(http.OK).send({userId: extUserId, redirect: '/'});
-    }
+      if (req.user) {
+        req.session.key = req.body.email;
+        req.session.userId = req.user._id;
+        var extUserId = req.user.externalId;
+        res.status(http.MOVED_TEMPORARILY).send({userId: extUserId, redirect: '/'});
+      }
   });
 
   /*

--- a/winterfell/run-tests.sh
+++ b/winterfell/run-tests.sh
@@ -10,7 +10,7 @@ pm2 start process.json
 
 # Then run node.js/express tests
 pm2 stop Express
-NODE_ENV=test ./node_modules/mocha/bin/mocha
+NODE_ENV=test ./node_modules/mocha/bin/mocha --timeout 10000
 
 # Cleanup microservice
 pm2 stop PdfMicroservice

--- a/winterfell/test/csrfTestUtils.js
+++ b/winterfell/test/csrfTestUtils.js
@@ -1,0 +1,6 @@
+module.exports = {
+
+  getCsrf: function (res) {
+    return unescape(/XSRF-TOKEN=(.*?);/.exec(res.headers['set-cookie'])[1]);
+  }
+};

--- a/winterfell/test/testBiscuit.js
+++ b/winterfell/test/testBiscuit.js
@@ -2,7 +2,6 @@ var Biscuit = require('../services/biscuit');
 var should = require('should');
 
 describe('Biscuit', function () {
-    this.timeout(20000);
     var server;
     var biscuit;
     before(function () {

--- a/winterfell/test/testMailingService.js
+++ b/winterfell/test/testMailingService.js
@@ -51,7 +51,6 @@ var testUser = {
 };
 
 describe('Mailing', function () {
-    this.timeout(10000);
     var server;
     var service;
     var testUserInstance;

--- a/winterfell/test/testUserController.js
+++ b/winterfell/test/testUserController.js
@@ -11,6 +11,7 @@ describe('UserController', function() {
   var targetUser;
   var server;
   var testSession;
+  var csrfToken;
 
   before(function () {
     server = require('../app');
@@ -51,7 +52,7 @@ describe('UserController', function() {
     testSession.get('/')
       .expect(200)
       .end(function(err, res) {
-        var csrfToken = csrfTestUtils.getCsrf(res);
+        csrfToken = csrfTestUtils.getCsrf(res);
         testSession.post('/api/auth/login')
           .send({email: targetUser.email, password: targetUser.password, _csrf: csrfToken})
           .expect(http.MOVED_TEMPORARILY, done);
@@ -65,15 +66,10 @@ describe('UserController', function() {
   });
 
   it('Delete user endpoint - success', function (done) {
-    testSession.get('/')
-      .expect(200)
-      .end(function(err, res) {
-        var csrfToken = csrfTestUtils.getCsrf(res);
-        testSession
-          .del('/api/user')
-          .set('X-XSRF-TOKEN', csrfToken)
-          .expect(http.OK, done);
-      });
+    testSession
+      .del('/api/user')
+      .set('X-XSRF-TOKEN', csrfToken)
+      .expect(http.OK, done);
   });
 
   xit('Modify user endpoint', function(done) {

--- a/winterfell/test/testUserController.js
+++ b/winterfell/test/testUserController.js
@@ -5,6 +5,7 @@ var httpErrors = require('./../utils/httpErrors');
 var User = require('../models/user');
 var session = require('supertest-session');
 var uuid = require('uuid');
+var csrfTestUtils = require('./csrfTestUtils');
 
 describe('UserController', function() {
   var targetUser;
@@ -43,25 +44,36 @@ describe('UserController', function() {
   it('Delete user endpoint - 404 if not authed', function(done) {
     testSession
       .del('/api/user')
-      .expect(http.NOT_FOUND, done);
+      .expect(http.FORBIDDEN, done);
   });
 
   it('should sign in', function (done) {
-    testSession.post('/api/auth/login')
-      .send({email: targetUser.email, password: targetUser.password})
-      .expect(200, done);
+    testSession.get('/')
+      .expect(200)
+      .end(function(err, res) {
+        var csrfToken = csrfTestUtils.getCsrf(res);
+        testSession.post('/api/auth/login')
+          .send({email: targetUser.email, password: targetUser.password, _csrf: csrfToken})
+          .expect(http.MOVED_TEMPORARILY, done);
+      });
   });
 
-  it('Get user endpoint - success', function(done) {
+  it('Get user endpoint - success', function (done) {
     testSession
-        .get('/api/user')
-        .expect(http.OK, done);
+      .get('/api/user')
+      .expect(http.OK, done);
   });
 
-  it('Delete user endpoint - success', function(done) {
-    testSession
-        .del('/api/user')
-        .expect(http.OK, done);
+  it('Delete user endpoint - success', function (done) {
+    testSession.get('/')
+      .expect(200)
+      .end(function(err, res) {
+        var csrfToken = csrfTestUtils.getCsrf(res);
+        testSession
+          .del('/api/user')
+          .set('X-XSRF-TOKEN', csrfToken)
+          .expect(http.OK, done);
+      });
   });
 
   xit('Modify user endpoint', function(done) {


### PR DESCRIPTION
I failed to noticed that the addition of the csurf middleware had broken all the tests, this fixes that br providing the token when needed (it is needed for any test that does an API POST or DEL)