### PR TITLE
hashed passwords in db

### DIFF
--- a/winterfell/controllers/authController.js
+++ b/winterfell/controllers/authController.js
@@ -142,11 +142,12 @@ module.exports = function (app) {
        }
        if (user) {
          if (AuthService.isPasswordCorrect(user.password, oldPwd)) {
-           // save new password
-           var hashedPwd = AuthService.generatePassword(req.body.new);
+           // save new password, and save a new salt
+           var salt = AuthService.generatePasswordSalt();
+           var hashedPwd = AuthService.generatePassword(req.body.new, salt);
            User.update(
              { _id: req.session.userId }, // query
-             { password: hashedPwd }, // new password
+             { password: hashedPwd, passwordSalt: hashedPwd }, // new password
              function() {
                 res.sendStatus(http.NO_CONTENT);
              }

--- a/winterfell/controllers/authController.js
+++ b/winterfell/controllers/authController.js
@@ -135,7 +135,7 @@ module.exports = function (app) {
    */
    app.post('/api/auth/password', auth.authenticatedOr404, function(req, res) {
      var oldPwd = req.body.old;
-     User.findById(req.session.userId).exec(function(err, user) {
+     User.findOneWithPassword({_id: req.session.userId}).exec(function(err, user) {
        if (err) {
          res.sendStatus(http.INTERNAL_SERVER_ERROR);
          return;

--- a/winterfell/middlewares/passport.js
+++ b/winterfell/middlewares/passport.js
@@ -7,6 +7,7 @@ var OAuth2Strategy = require('passport-oauth').OAuth2Strategy;
 var httpErrors = require('./../utils/httpErrors');
 var Constants = require('./../utils/constants');
 var User = require('../models/user');
+var Log = require('../middlewares/log');
 var SocialUser = require('../utils/socialUser');
 var AuthService = require('../services/authService');
 
@@ -35,8 +36,7 @@ module.exports = function (app) {
     });
 
     function localStrategyHandler (req, email, password, next) {
-      console.log('evaluating email ' + email);
-      console.log('evaluating password ' + password);
+        Log.console('Evaluating account: ' + email);
         var normalizedEmail = _.isString(email) ? email.toLowerCase() : email;
 
         User.findOne({ email: normalizedEmail, state: User.State.ACTIVE }, function (err, user) {

--- a/winterfell/middlewares/passport.js
+++ b/winterfell/middlewares/passport.js
@@ -39,7 +39,8 @@ module.exports = function (app) {
         Log.console('Evaluating account: ' + email);
         var normalizedEmail = _.isString(email) ? email.toLowerCase() : email;
 
-        User.findOne({ email: normalizedEmail, state: User.State.ACTIVE }, function (err, user) {
+        var query = { email: normalizedEmail, state: User.State.ACTIVE };
+        User.findOneWithPassword(query).exec(function(err, user) {
             if (err) {
               return next(err);
             }

--- a/winterfell/models/user.js
+++ b/winterfell/models/user.js
@@ -24,8 +24,8 @@ var UserSchema = new Schema({
   lastname: String,                   // Last name
   email: String,                      // Email address
   externalId: String,                 // External User Id
-  password: {type: String, select: false},      // Encrypted password
-  passwordSalt: {type: String, select: false},  // Password Salt for encrypting passwords
+  password: {type: String, select: false},      // Encrypted password, hide from app
+  passwordSalt: {type: String, select: false},  // Password Salt for encrypting passwords, hide from app
   state: String,                      // User.State
   stateUpdatedAt: Date,               // Date of last state modification
   socialUsers: [socialUserSchema],

--- a/winterfell/models/user.js
+++ b/winterfell/models/user.js
@@ -24,8 +24,8 @@ var UserSchema = new Schema({
   lastname: String,                   // Last name
   email: String,                      // Email address
   externalId: String,                 // External User Id
-  password: String,                   // Encrypted password
-  passwordSalt: String,               // Password Salt for encrypting passwords
+  password: {type: String, select: false},      // Encrypted password
+  passwordSalt: {type: String, select: false},  // Password Salt for encrypting passwords
   state: String,                      // User.State
   stateUpdatedAt: Date,               // Date of last state modification
   socialUsers: [socialUserSchema],
@@ -78,3 +78,10 @@ var User = mongoose.model('User', UserSchema);
 module.exports = User;
 module.exports.Schema = UserSchema;
 module.exports.State = State;
+
+// By default, password and passwordSalt should not be revealed to the rest of the app.
+// However, for several authentication purposes, we'll need to compare passwords
+// in which case, the password needs to be selected from db
+module.exports.findOneWithPassword = function(query) {
+  return User.findOne(query).select('+password +passwordSalt');
+};

--- a/winterfell/models/user.js
+++ b/winterfell/models/user.js
@@ -25,6 +25,7 @@ var UserSchema = new Schema({
   email: String,                      // Email address
   externalId: String,                 // External User Id
   password: String,                   // Encrypted password
+  passwordSalt: String,               // Password Salt for encrypting passwords
   state: String,                      // User.State
   stateUpdatedAt: Date,               // Date of last state modification
   socialUsers: [socialUserSchema],
@@ -55,6 +56,7 @@ UserSchema.statics.quickCreate = function(user, callback) {
     lastname: user.lastname,
     email: user.email,
     password: user.password,
+    passwordSalt: user.passwordSalt,
     externalId: uuid.v4(),
     state: User.State.ACTIVE,
     stateUpdatedAt: now,

--- a/winterfell/package.json
+++ b/winterfell/package.json
@@ -18,6 +18,7 @@
     "api-check": "^7.5.5",
     "async": "^0.9.2",
     "aws-sdk": "^2.6.9",
+    "bcryptjs": "^2.3.0",
     "body-parser": "^1.15.2",
     "browser-sync": "^2.12.5",
     "browserify": "^13.1.0",

--- a/winterfell/services/authService.js
+++ b/winterfell/services/authService.js
@@ -1,21 +1,23 @@
 var _ = require('lodash');
+var bcrypt = require('bcryptjs');
 var SocialUser = require('../utils/socialUser');
 var User = require('../models/user');
 var UserValues = require('../models/userValues');
 var UserService = require('../services/userService');
+
+var salt = bcrypt.genSaltSync(10);
 
 function AuthService (app) {
     this.app = app;
 };
 
 module.exports = AuthService;
+module.exports.generatePassword = function(pwd) {
+  return bcrypt.hashSync(pwd, salt);
+};
+
 module.exports.isPasswordCorrect = function (expectedPwd, candidatePwd) {
-  console.log('[AuthService] compare passwords: ' + expectedPwd + ' vs. ' + candidatePwd);
-  if (_.isEqual(expectedPwd, candidatePwd)) {
-    return true;
-  } else {
-    return false;
-  }
+  return bcrypt.compareSync(candidatePwd, expectedPwd);
 };
 
 /**

--- a/winterfell/services/authService.js
+++ b/winterfell/services/authService.js
@@ -5,14 +5,18 @@ var User = require('../models/user');
 var UserValues = require('../models/userValues');
 var UserService = require('../services/userService');
 
-var salt = bcrypt.genSaltSync(10);
+var DEFAULT_SALT_ROUNDS = 10;
 
 function AuthService (app) {
     this.app = app;
 };
 
 module.exports = AuthService;
-module.exports.generatePassword = function(pwd) {
+module.exports.generatePasswordSalt = function() {
+  return bcrypt.genSaltSync(DEFAULT_SALT_ROUNDS);
+};
+
+module.exports.generatePassword = function(pwd, salt) {
   return bcrypt.hashSync(pwd, salt);
 };
 

--- a/winterfell/services/userService.js
+++ b/winterfell/services/userService.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var AuthService = require('./authService');
 var http = require('http-status-codes');
 var httpErrors = require('./../utils/httpErrors');
 var SocialUser = require('./../utils/socialUser');
@@ -37,13 +38,14 @@ module.exports.createNewUser = function(user, callback) {
     errorObj.msg = httpErrors.INVALID_PASSWORD;
   }
 
+  var hashedPwd = AuthService.generatePassword(password);
   if (errorObj.code == 0) {
     var newUser = {
       firstname: null,
       middlename: null,
       lastname: null,
       email: email,
-      password: password,
+      password: hashedPwd,
       admin: user.admin,
       test: user.test
     };

--- a/winterfell/services/userService.js
+++ b/winterfell/services/userService.js
@@ -38,7 +38,8 @@ module.exports.createNewUser = function(user, callback) {
     errorObj.msg = httpErrors.INVALID_PASSWORD;
   }
 
-  var hashedPwd = AuthService.generatePassword(password);
+  var salt = AuthService.generatePasswordSalt();
+  var hashedPwd = AuthService.generatePassword(password, salt);
   if (errorObj.code == 0) {
     var newUser = {
       firstname: null,
@@ -46,6 +47,7 @@ module.exports.createNewUser = function(user, callback) {
       lastname: null,
       email: email,
       password: hashedPwd,
+      passwordSalt: salt,
       admin: user.admin,
       test: user.test
     };

--- a/winterfell/test/testClaimController.js
+++ b/winterfell/test/testClaimController.js
@@ -37,20 +37,22 @@ describe('ClaimController', function() {
   var server;
   var testSession;
   var csrfToken;
+  var originalPwd = 'qwerasdf';
+
+  var userInput = {
+    firstname: 'Sir',
+    middlename: 'Moose',
+    lastname: 'Alot',
+    email: 'sirmoosealot@test.com',
+    password: originalPwd
+  };
 
   before(function(done) {
     server = require('../app');
     testSession = session(server);
 
     User.remove({}, function() {
-      User.create({
-        firstname: 'Sir',
-        middlename: 'Moose',
-        lastname: 'Alot',
-        email: 'sirmoosealot@test.com',
-        password: 'qwerasdf',
-        state: User.State.ACTIVE
-      }, function(err, user) {
+      UserService.createNewUser(userInput, function(err, user) {
         targetUser = user;
         done();
       });
@@ -73,7 +75,7 @@ describe('ClaimController', function() {
       .end(function(err, res) {
         csrfToken = csrfTestUtils.getCsrf(res);
         testSession.post('/api/auth/login')
-          .send({email: targetUser.email, password: targetUser.password, _csrf: csrfToken})
+          .send({email: targetUser.email, password: originalPwd, _csrf: csrfToken})
           .expect(http.MOVED_TEMPORARILY, done);
       });
   });
@@ -199,6 +201,7 @@ describe('ClaimController', function() {
 
 describe('SaveClaimController', function () {
   var testSession, server, targetUser, targetClaim, csrfToken;
+  var originalPwd = 'qwerasdf';
 
   before(function (done) {
     this.timeout(20000);
@@ -217,10 +220,9 @@ describe('SaveClaimController', function () {
         firstname: 'User1',
         lastname: 'McUser',
         email: 'user1@email.com',
-        password: 'testword',
-        state: User.State.ACTIVE
+        password: originalPwd
       };
-      return User.create(user);
+      return UserService.createNewUser(user);
     });
 
     promise = promise.then(function (user) {
@@ -260,13 +262,12 @@ describe('SaveClaimController', function () {
       .end(function(err, res) {
         csrfToken = csrfTestUtils.getCsrf(res);
         testSession.post('/api/auth/login')
-          .send({email: targetUser.email, password: targetUser.password, _csrf: csrfToken})
+          .send({email: targetUser.email, password: originalPwd, _csrf: csrfToken})
           .expect(http.MOVED_TEMPORARILY, done);
       });
   });
 
   it('Should save the claim form after signin', function(done) {
-    console.log(targetClaim);
     testSession
       .post('/api/save/' + targetClaim._id + '/VBA-21-0966-ARE')
       .set('X-XSRF-TOKEN', csrfToken)
@@ -342,11 +343,11 @@ describe('SaveClaimController', function () {
         User.findOne({_id: targetUser._id}, function(error, user) {
           should.not.exist(error);
           should.exist(user);
-          user.firstname.should.equal('User1');
+          user.firstname.should.equal('joe');
           user.contact.address.city.should.equal('city1');
           done();
         })
-      })
+      });
   });
 
   it('Should retrieve the rendered form after save', function(done) {

--- a/winterfell/test/testUserController.js
+++ b/winterfell/test/testUserController.js
@@ -1,31 +1,31 @@
 'use strict';
+var csrfTestUtils = require('./csrfTestUtils');
 var http = require('http-status-codes');
 var httpErrors = require('./../utils/httpErrors');
 var session = require('supertest-session');
 var should = require('should');
 var User = require('../models/user');
+var UserService = require('./../services/userService');
 var uuid = require('uuid');
-var csrfTestUtils = require('./csrfTestUtils');
 
 describe('UserController', function() {
   var targetUser;
   var server;
   var testSession;
   var csrfToken;
+  var originalPwd = 'qwerasdf';
 
   before(function () {
     server = require('../app');
     testSession = session(server);
 
     User.remove({}, function() {
-      User.create({
+      UserService.createNewUser({
         firstname: 'Sir',
         middlename: 'Moose',
         lastname: 'Alot',
         email: 'sirmoosealot@test.com',
-        password: 'qwerasdf',
-        externalId: uuid.v4(),
-        state: User.State.ACTIVE
+        password: originalPwd
       }, function(err, user) {
         targetUser = user;
       });
@@ -54,7 +54,7 @@ describe('UserController', function() {
       .end(function(err, res) {
         csrfToken = csrfTestUtils.getCsrf(res);
         testSession.post('/api/auth/login')
-          .send({email: targetUser.email, password: targetUser.password, _csrf: csrfToken})
+          .send({email: targetUser.email, password: originalPwd, _csrf: csrfToken})
           .expect(http.MOVED_TEMPORARILY, done);
       });
   });


### PR DESCRIPTION
use `bcrypt` to hash passwords before saving them to db.
Then use `bcrypt` to compare passwords.

This mostly affects tests as we assumed the original password with the crsf tokens.

production wise: PREVIOUS ACCOUNTS WONT WORK ANYMORE.
I think it's okay because we have no users?