### PR TITLE
claim submit error should route to submit-error page

### DIFF
--- a/winterfell/webapp/src/js/app.js
+++ b/winterfell/webapp/src/js/app.js
@@ -171,7 +171,7 @@ app.config(['$stateProvider', '$urlRouterProvider', function ($stateProvider, $u
 
   $stateProvider.state({
     name: 'root.claimsubmit',
-    url: '/claim/{claimId}/submit',
+    url: '/claim/{claimId}/submit?error',
     templateUrl: 'templates/claimSubmitted.html',
     controller: 'claimSubmittedCtrl'
   });

--- a/winterfell/webapp/src/js/claimConfirmCtrl.js
+++ b/winterfell/webapp/src/js/claimConfirmCtrl.js
@@ -73,13 +73,12 @@ app.controller('claimConfirmCtrl', ['$scope', '$state', '$stateParams', 'net', '
       };
       net.submitClaim($stateParams.claimId, data)
         .then(function (resp) {
-          // todo: set claim state or re-fetch all user claims?
           if (resp) {
             claimService.submitCurrentClaim();
             $state.go("root.claimsubmit", {claimId: $stateParams.claimId});
-          } else {
-            $state.go("root.claimsubmit", {claimId: $stateParams.claimId, error: 'missing'});
           }
+        }).catch(function (data) {
+          $state.go("root.claimsubmit", {claimId: $stateParams.claimId, error: 'unknown'});
         });
     };
   }

--- a/winterfell/webapp/src/styles/home.styl
+++ b/winterfell/webapp/src/styles/home.styl
@@ -1,7 +1,8 @@
 @import "standards.styl"
 
-mainWrapperSize = 250px
-innerWrapperSize = 80px
+mainWrapperSize = 200px
+innerWrapperSize = 60px
+actionWindowMaxPx = 767px // Hack for media screen. Minor conflicts between media screening and bootstrap columns
 
 #vfi-home-view
   background-color: colorWhite
@@ -68,7 +69,7 @@ innerWrapperSize = 80px
       padding-left: 30px
       text-align: left
 
-      @media screen and (max-width: maxWindowWidthPx)
+      @media screen and (max-width: actionWindowMaxPx)
         text-align: center
 
       & h4
@@ -88,7 +89,7 @@ innerWrapperSize = 80px
       &.left-align
         float: left
 
-      @media screen and (max-width: maxWindowWidthPx)
+      @media screen and (max-width: actionWindowMaxPx)
         margin: largeSpacing auto
         float: initial !important
 
@@ -99,14 +100,14 @@ innerWrapperSize = 80px
       transform: translate(-50%, -50%)
 
       &.folder
-        width: 180px
-        height: 180px
+        width: 140px
+        height: 140px
         background: url('../icons/folder.svg')
         background-size: cover
         background-repeat: no-repeat
       &.health
-        width: 110px
-        height: 110px
+        width: 90px
+        height: 90px
         background: url('../icons/health-white.svg')
         background-size: cover
         background-repeat: no-repeat
@@ -137,14 +138,14 @@ innerWrapperSize = 80px
         transform: translate(-50%, -50%)
 
         &.checkmark
-          width: 30px
-          height: 30px
+          width: 25px
+          height: 25px
           background: url('../icons/checkmark-white.svg')
           background-size: cover
           background-repeat: no-repeat
         &.question
-          width: 10px
-          height: 30px
+          width: 7px
+          height: 22px
           background: url('../icons/info-white.svg')
           background-size: cover
           background-repeat: no-repeat

--- a/winterfell/webapp/src/templates/claimConfirm.pug
+++ b/winterfell/webapp/src/templates/claimConfirm.pug
@@ -17,7 +17,7 @@
       h4 General
       div.basic-row
         span Name:
-        span {{user.firstName}} {{user.lastName}}
+        span {{user.firstname}} {{user.lastname}}
       div.basic-row
         span Today's date:
         span 9/12/2016

--- a/winterfell/webapp/src/templates/claimSubmitted.pug
+++ b/winterfell/webapp/src/templates/claimSubmitted.pug
@@ -10,6 +10,7 @@
     div.message.error(ng-show="rejected")
       p Sorry, but it seems like your claim was rejected. You may either:
       ul
+        li Click #[a(ui-sref="root.claimconfirm({claimId: claimId})") here] to double-check that your information is correct.
         li #[a(href="#/contact") Contact us] for additional help.
         li Download your claim #[a(ui-sref="root.profile.claims") here] to bring to your nearest Veterans Affairs branch.
 


### PR DESCRIPTION
When there is an error on the `submit` endpoint, route to the submit error page.

* a small bug change with name fields
* a few style changes on home screen