### PR TITLE
Fix Form Download Buttons

### DIFF
--- a/winterfell/controllers/claimController.js
+++ b/winterfell/controllers/claimController.js
@@ -346,6 +346,7 @@ module.exports = function (app) {
       res
         .status(http.OK)
         .set('Content-Type', 'application/pdf')
+        .set('Content-Length', form.pdf.length)
         .send(form.pdf);
     }, function failure(err) {
       console.error(err.stack);

--- a/winterfell/webapp/src/js/formCtrl.js
+++ b/winterfell/webapp/src/js/formCtrl.js
@@ -9,6 +9,8 @@ app.controller('formCtrl', ['$scope', '$filter', '$rootScope', 'formTemplateServ
               $stateParams, $state, userValues, $window, net, $interval) {
       $scope.title = formTemplateService[$stateParams.formId].vfi.title;
       $scope.description = formTemplateService[$stateParams.formId].vfi.description;
+      $scope.claimId = $stateParams.claimId;
+      $scope.formId = $stateParams.formId;
 
       $scope.$watch('signature', function (newVal) {
         if (newVal) {
@@ -25,7 +27,7 @@ app.controller('formCtrl', ['$scope', '$filter', '$rootScope', 'formTemplateServ
       $scope.onRender = function () {
         save(true).then(
           function success() {
-            $window.location.href = '/claim/' + $stateParams.claimId + '/form/' + $stateParams.formId + '/pdf';
+            $window.location = '/claim/' + $stateParams.claimId + '/form/' + $stateParams.formId + '/pdf';
           }
         );
       };

--- a/winterfell/webapp/src/js/formCtrl.js
+++ b/winterfell/webapp/src/js/formCtrl.js
@@ -24,14 +24,6 @@ app.controller('formCtrl', ['$scope', '$filter', '$rootScope', 'formTemplateServ
         return $filter('date')(new Date(), 'MM/dd/yyyy');
       }
 
-      $scope.onRender = function () {
-        save(true).then(
-          function success() {
-            $window.location = '/claim/' + $stateParams.claimId + '/form/' + $stateParams.formId + '/pdf';
-          }
-        );
-      };
-
       $scope.onSubmit = function () {
         save(true).then(
           function () {

--- a/winterfell/webapp/src/js/signatureDirective.js
+++ b/winterfell/webapp/src/js/signatureDirective.js
@@ -13,7 +13,7 @@ angular.module('signature').directive('signaturePad', ['$window', '$timeout',
     return {
       restrict: 'EA',
       replace: true,
-      template: '<div class="signature"><canvas ng-mouseup="updateModel()"></canvas></div>',
+      template: '<div class="signature"><canvas class="signature-canvas" ng-mouseup="updateModel()"></canvas></div>',
       scope: {
         clear: '=',
         dataurl: '='

--- a/winterfell/webapp/src/styles/claimSelectForms.styl
+++ b/winterfell/webapp/src/styles/claimSelectForms.styl
@@ -72,7 +72,7 @@
         width: 100%
         text-align: center
 
-      & button
+      & button, & .btn
         display: inline-block
         width: 9em
         margin-bottom: smallSpacing

--- a/winterfell/webapp/src/styles/form.styl
+++ b/winterfell/webapp/src/styles/form.styl
@@ -62,8 +62,7 @@
         background-color: colorLightGray
         color: colorBlack
 
-    &.download
-    &.save
+    &.save, &.download
       float: left
       margin: 0 miniSpacing
 
@@ -100,3 +99,7 @@ div.has-success::before
   right: 35px
   top: 60px
   margin-top: -25px
+
+canvas.signature-canvas
+  width: 100%
+  height: 100%

--- a/winterfell/webapp/src/styles/main.styl
+++ b/winterfell/webapp/src/styles/main.styl
@@ -17,7 +17,7 @@ body
 			color: colorRed
 			text-decoration: underline
 
-	& button
+	& button, & a.btn
 		padding: 10px 20px
 		background-color: colorPrimaryDarkBlue
 		border-radius: 3px
@@ -25,8 +25,10 @@ body
 		outline: none
 		color: white
 		font-size: bodyFont_size
+		line-height: bodyFont_lineHeight
 
-		&:hover
+		&:hover, &:focus
+			color: white
 			filter: brightness(1.2)
 			-webkit-filter: brightness(1.2)
 			-moz-filter: brightness(1.2)

--- a/winterfell/webapp/src/templates/claimSelectForms.pug
+++ b/winterfell/webapp/src/templates/claimSelectForms.pug
@@ -22,10 +22,9 @@
           button.edit-btn(ui-sref="root.form({claimId: claimId, formId: formId})")
             div.edit-icon
             | Edit
-          a(href="{{'claim/' + claimId + '/form/' + formId + '/pdf'}}")
-            button.download-btn
-              div.download-icon
-              | Download
+          a(class="btn download-btn" href="/claim/{{claimId}}/form/{{formId}}/pdf" download="{{formId}}.pdf")
+            div.download-icon
+            | Download
 
     div.button-wrapper
       button.cancel-btn(ng-click="onClickCancel()") Cancel

--- a/winterfell/webapp/src/templates/form.pug
+++ b/winterfell/webapp/src/templates/form.pug
@@ -23,7 +23,7 @@ div#vfi-form-view
                         | Submit
                     button.save(type="button" ng-click="onSave()")
                         | Save Information
-                    button.download(type="button" ng-click="onRender()")
+                    a(class="download btn" href="/claim/{{claimId}}/form/{{formId}}/pdf" download="{{formId}}.pdf")
                         | Download
 
 


### PR DESCRIPTION
- Change all form download buttons to `<a>` elements with the HTML5 `download` property set correctly.
- Update CSS so we can use `a.btn` elements in place of `button` elements.
- Change instances of `button` nested in `a`, since that is illegal and wont be handled properly by all browsers. 
- Fix additional issue with signatue `<canvas>` element being too big in some browsers.